### PR TITLE
Fix and enable CI in other OSs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,11 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         java-version: [ 8 , 11 , 14 , 16 ]
+        os: [ ubuntu-latest , macos-latest , windows-latest ]
 
     steps:
       - name: Checkout
@@ -20,6 +21,7 @@ jobs:
           distribution: 'adopt'
       - name: Install example projects
         run: ./.github/install_examples.sh
+        shell: bash
       - name: Build and run tests
         run: mvn --batch-mode clean test
       - name: Publish test reports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,5 @@ jobs:
         shell: bash
       - name: Build and run tests
         run: mvn --batch-mode clean test
-      - name: Publish test reports
-        if: ${{ always() }}
-        uses: scacap/action-surefire-report@v1.0.12
       - name: Codecov
         uses: codecov/codecov-action@v1.5.2

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -2,6 +2,8 @@ package fr.spoonlabs.flacoco.core.config;
 
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 
+import java.io.File;
+
 /**
  * Config manager for Flacoco.
  *
@@ -42,9 +44,9 @@ public class FlacocoConfig {
 	}
 
 	private void initDefaults() {
-		this.workspace = "./";
-		this.projectPath = "./";
-		this.classpath = "./";
+		this.workspace = new File("./").getAbsolutePath();
+		this.projectPath = new File("./").getAbsolutePath();
+		this.classpath = new File("./").getAbsolutePath();
 		this.testFramework = TestFramework.JUNIT4;
 		this.coverTests = false;
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -33,8 +33,10 @@ public class CoverageRunner {
 		CoverageMatrix matrixExecutionResult = new CoverageMatrix();
 
 		// Compute target path
-		String pathToClasses = this.config.getProjectPath() + File.separator + "target/classes/";
-		String pathToTestClasses = this.config.getProjectPath() + File.separator + "target/test-classes/";
+		String pathToClasses = new File(this.config.getProjectPath() + File.separator + "target/classes/")
+				.getAbsolutePath();
+		String pathToTestClasses = new File(this.config.getProjectPath() + File.separator + "target/test-classes/")
+				.getAbsolutePath();
 
 		// Get JacocoRunner
 		JacocoRunner runner = getJacocoRunner(pathToClasses, pathToTestClasses);

--- a/src/main/java/fr/spoonlabs/flacoco/core/test/TestDetector.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/test/TestDetector.java
@@ -23,8 +23,8 @@ public class TestDetector {
 	public List<TestInformation> findTests() {
 		// Create Spoon model to retrieve information about the tests
 		Launcher laucher = new Launcher();
-		laucher.addInputResource(this.config.getProjectPath() + File.separator + "src/main");
-		laucher.addInputResource(this.config.getProjectPath() + File.separator + "src/test");
+		laucher.addInputResource(new File(this.config.getProjectPath() + File.separator + "src/main").getAbsolutePath());
+		laucher.addInputResource(new File(this.config.getProjectPath() + File.separator + "src/test").getAbsolutePath());
 		laucher.buildModel();
 
 		// Init test framework

--- a/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
@@ -26,8 +26,8 @@ public class SpoonConverter {
 
 		// Init spoon Launcher
 		Launcher launcher = new Launcher();
-		launcher.addInputResource(config.getProjectPath() + File.separator + "src/main");
-		launcher.addInputResource(config.getProjectPath() + File.separator + "src/test");
+		launcher.addInputResource(new File(config.getProjectPath() + File.separator + "src/main").getAbsolutePath());
+		launcher.addInputResource(new File(config.getProjectPath() + File.separator + "src/test").getAbsolutePath());
 		launcher.buildModel();
 		launcher.addProcessor(new SpoonLocalizedFaultFinder());
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -39,7 +39,7 @@ public class FlacocoTest {
 	public void testExampleFL1SpectrumBasedOchiaiDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
@@ -76,7 +76,7 @@ public class FlacocoTest {
 	public void testExampleFL2SpectrumBasedOchiaiDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL2/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL2/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
@@ -110,7 +110,7 @@ public class FlacocoTest {
 	public void testExampleFL3SpectrumBasedOchiaiDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL3/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
@@ -144,7 +144,7 @@ public class FlacocoTest {
 	public void testExampleFL1SpectrumBasedOchiaiCoverTestsDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 		config.setCoverTests(true);
@@ -180,7 +180,7 @@ public class FlacocoTest {
 	public void testExampleFL1SpectrumBasedOchiaiSpoonMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
@@ -196,7 +196,9 @@ public class FlacocoTest {
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
-			assertTrue(ctStatement.getPosition().getFile().getAbsolutePath().endsWith("fr/spoonlabs/FLtest1/Calculator.java"));
+			// Assert location is Calculator.java, regex for matching both unix and dos paths
+			assertTrue(ctStatement.getPosition().getFile().getAbsolutePath()
+					.matches(".*(fr)[\\\\/](spoonlabs)[\\\\/](FLtest1)[\\\\/](Calculator)\\.(java)$"));
 			switch (ctStatement.getPosition().getLine()) {
 				// Line executed only by the failing
 				case 15:

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -37,7 +37,7 @@ public class CoverageRunnerTest {
 	public void testExampleFL1() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 
 		CoverageRunner detector = new CoverageRunner();
 
@@ -138,7 +138,7 @@ public class CoverageRunnerTest {
 	public void testExampleFL2() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL2/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL2/FLtest1").getAbsolutePath());
 
 		CoverageRunner detector = new CoverageRunner();
 
@@ -171,7 +171,7 @@ public class CoverageRunnerTest {
 	public void testExampleFL3() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL3/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
 
 		CoverageRunner detector = new CoverageRunner();
 
@@ -207,7 +207,7 @@ public class CoverageRunnerTest {
 	public void testExampleFL1CoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 
 		CoverageRunner detector = new CoverageRunner();
 

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -36,7 +36,7 @@ public class TestDetectorTest {
 	public void testExampleFL1() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 
 		// Find the tests
 		TestDetector testDetector = new TestDetector();
@@ -53,7 +53,7 @@ public class TestDetectorTest {
 	public void testExampleFL2() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL2/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL2/FLtest1").getAbsolutePath());
 
 		// Find the tests
 		TestDetector testDetector = new TestDetector();
@@ -70,7 +70,7 @@ public class TestDetectorTest {
 	public void testExampleFL3() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL3/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
 
 		// Find the tests
 		TestDetector testDetector = new TestDetector();

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -33,7 +33,7 @@ public class SpectrumRunnerTest {
 	public void testExampleFL1Ochiai() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
 		SpectrumRunner runner = new SpectrumRunner();
@@ -63,7 +63,7 @@ public class SpectrumRunnerTest {
 	public void testExampleFL2Ochiai() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL2/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL2/FLtest1").getAbsolutePath());
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
 		SpectrumRunner runner = new SpectrumRunner();
@@ -94,7 +94,7 @@ public class SpectrumRunnerTest {
 	public void testExampleFL3Ochiai() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL3/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
 		SpectrumRunner runner = new SpectrumRunner();
@@ -125,7 +125,7 @@ public class SpectrumRunnerTest {
 	public void testExampleFL1OchiaiCoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL1/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 		config.setCoverTests(true);
 

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
@@ -39,7 +39,7 @@ public class SpoonConverterTest {
 	public void testConvertSpoonExample() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		config.setProjectPath("./examples/exampleFL3/FLtest1");
+		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 


### PR DESCRIPTION
- Fix build on Windows
- Enable CI on MacOS and Windows

So, there were two issues. First, the install script for the example projects wasn't running on bash in the windows jobs, since bash isn't the default shell. Then, the paths to the example projects needed to be absolute paths because of the dos paths being different from the unix paths.