### PR TITLE
Implement JUnit5 support

### DIFF
--- a/.github/install_examples.sh
+++ b/.github/install_examples.sh
@@ -5,3 +5,4 @@
 mvn clean test -DskipTests -B -f examples/exampleFL1/FLtest1/
 mvn clean test -DskipTests -B -f examples/exampleFL2/FLtest1/
 mvn clean test -DskipTests -B -f examples/exampleFL3/FLtest1/
+mvn clean test -DskipTests -B -f examples/exampleFL4/FLtest1/

--- a/examples/exampleFL4/FLtest1/pom.xml
+++ b/examples/exampleFL4/FLtest1/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>fr.spoonlabs</groupId>
+  <artifactId>FLtest1</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>FLtest1</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.7.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/examples/exampleFL4/FLtest1/src/main/java/fr/spoonlabs/FLtest1/Calculator.java
+++ b/examples/exampleFL4/FLtest1/src/main/java/fr/spoonlabs/FLtest1/Calculator.java
@@ -1,0 +1,23 @@
+package fr.spoonlabs.FLtest1;
+
+public class Calculator {
+
+	public Calculator() {
+	}
+
+	public int calculate(String op, int op1, int op2) {
+
+		if (op.equals("+")) {
+			return op1 + op2;
+		} else if (op.equals("-")) {
+			return op1 - op2;
+		} else if (op.equals("*")) {
+			return op1 / op2;//buggy
+		} else if (op.equals("/")) {
+			return op1 / op2;
+		} else if (op.equals("%")) {
+			return op1 % op2;
+		}
+		throw new UnsupportedOperationException(op);
+	}
+}

--- a/examples/exampleFL4/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
+++ b/examples/exampleFL4/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
@@ -1,0 +1,39 @@
+package fr.spoonlabs.FLtest1;
+
+import org.junit.jupiter.api.Assertions;
+
+import org.junit.jupiter.api.Test;
+
+public class CalculatorTest {
+
+	Calculator c = new Calculator();
+
+	@Test
+	public void testSum() {
+
+		Assertions.assertEquals(4, c.calculate("+", 3, 1));
+
+	}
+
+	@Test
+	public void testSubs() {
+
+		Assertions.assertEquals(2, c.calculate("-", 3, 1));
+
+	}
+
+	@Test
+	public void testMul() {
+
+		Assertions.assertEquals(8, c.calculate("*", 4, 2));
+
+	}
+
+	@Test
+	public void testDiv() {
+
+		Assertions.assertEquals(2, c.calculate("/", 12, 6));
+
+	}
+
+}

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -4,6 +4,7 @@ import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.listener.CoveredTestResult;
 import eu.stamp_project.testrunner.listener.impl.CoverageCollectorDetailed;
 import eu.stamp_project.testrunner.runner.coverage.JUnit4JacocoRunner;
+import eu.stamp_project.testrunner.runner.coverage.JUnit5JacocoRunner;
 import eu.stamp_project.testrunner.runner.coverage.JacocoRunner;
 import fr.spoonlabs.flacoco.api.Flacoco;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
@@ -107,6 +108,13 @@ public class CoverageRunner {
 	}
 
 	private JacocoRunner getJacocoRunner(String sourceClasses, String testClasses) {
-		return new JUnit4JacocoRunner(sourceClasses, testClasses, new CoverageCollectorDetailed());
+		switch (this.config.getTestFramework()) {
+			case JUNIT4:
+				return new JUnit4JacocoRunner(sourceClasses, testClasses, new CoverageCollectorDetailed());
+			case JUNIT5:
+				return new JUnit5JacocoRunner(sourceClasses, testClasses, new CoverageCollectorDetailed());
+			default:
+				return null;
+		}
 	}
 }

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -27,7 +27,8 @@ public class FlacocoTest {
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
-		config.setClasspath(dep1 + File.separator + dep2);
+		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();
+		config.setClasspath(dep1 + File.pathSeparatorChar + dep2 + File.pathSeparatorChar + dep3);
 	}
 
 	@After
@@ -218,7 +219,122 @@ public class FlacocoTest {
 					break;
 			}
 		}
+	}
 
+	@Test
+	public void testExampleFL4JUnit5SpectrumBasedOchiaiDefaultMode() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<String, Double> susp = flacoco.runDefault();
+
+		for (String line : susp.keySet()) {
+			System.out.println("" + line + " " + susp.get(line));
+		}
+
+		assertEquals(6, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14"), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
+	}
+
+	@Test
+	public void testExampleFL4JUnit5SpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+		config.setCoverTests(true);
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<String, Double> susp = flacoco.runDefault();
+
+		for (String line : susp.keySet()) {
+			System.out.println("" + line + " " + susp.get(line));
+		}
+
+		assertEquals(8, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14"), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
+	}
+
+	@Test
+	public void testExampleFL4JUnit5SpectrumBasedOchiaiSpoonMode() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<CtStatement, Double> susp = flacoco.runSpoon();
+
+		// Fails because two original keys get mapped to the same CtStatement
+		//assertEquals(6, susp.size());
+		assertEquals(5, susp.size());
+
+		for (CtStatement ctStatement : susp.keySet()) {
+			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
+			// Assert location is Calculator.java, regex for matching both unix and dos paths
+			assertTrue(ctStatement.getPosition().getFile().getAbsolutePath()
+					.matches(".*(fr)[\\\\/](spoonlabs)[\\\\/](FLtest1)[\\\\/](Calculator)\\.(java)$"));
+			switch (ctStatement.getPosition().getLine()) {
+				// Line executed only by the failing
+				case 15:
+					assertEquals(1.0, susp.get(ctStatement), 0);
+					break;
+				// Line executed by failing and passing
+				case 14:
+					assertEquals(0.70, susp.get(ctStatement), 0.01);
+					break;
+				case 12:
+					assertEquals(0.57, susp.get(ctStatement), 0.01);
+					break;
+				// Lines executed by all test
+				case 10:
+				case 5:
+					assertEquals(0.5, susp.get(ctStatement), 0);
+					break;
+			}
+		}
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -24,7 +24,8 @@ public class TestDetectorTest {
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
-		config.setClasspath(dep1 + File.separator + dep2);
+		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();
+		config.setClasspath(dep1 + File.pathSeparatorChar + dep2 + File.pathSeparatorChar + dep3);
 	}
 
 	@After
@@ -81,6 +82,24 @@ public class TestDetectorTest {
 		// Check that there are 5 test methods in the test class
 		TestInformation testInformation = tests.get(0);
 		assertEquals(5, testInformation.getTestMethods().size());
+	}
+
+	@Test
+	public void testExampleFL4JUnit5() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+
+		// Find the tests
+		TestDetector testDetector = new TestDetector();
+		List<TestInformation> tests = testDetector.findTests();
+
+		// Check that there is one test class
+		assertEquals(1, tests.size());
+		// Check that there are 4 test methods in the test class
+		TestInformation testInformation = tests.get(0);
+		assertEquals(4, testInformation.getTestMethods().size());
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -21,7 +21,8 @@ public class SpectrumRunnerTest {
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
-		config.setClasspath(dep1 + File.separator + dep2);
+		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();
+		config.setClasspath(dep1 + File.pathSeparatorChar + dep2 + File.pathSeparatorChar + dep3);
 	}
 
 	@After
@@ -153,4 +154,70 @@ public class SpectrumRunnerTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
+
+	@Test
+	public void testExampleFL4JUnit5Ochiai() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+
+		SpectrumRunner runner = new SpectrumRunner();
+
+		Map<String, Double> susp = runner.run();
+
+		for (String line : susp.keySet()) {
+			System.out.println("susp " + line + " " + susp.get(line));
+		}
+
+		assertEquals(6, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14"), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
+	}
+
+	@Test
+	public void testExampleFL4JUnit5OchiaiCoverTests() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL4/FLtest1").getAbsolutePath());
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setTestFramework(FlacocoConfig.TestFramework.JUNIT5);
+		config.setCoverTests(true);
+
+		SpectrumRunner runner = new SpectrumRunner();
+
+		Map<String, Double> susp = runner.run();
+
+		for (String line : susp.keySet()) {
+			System.out.println("susp " + line + " " + susp.get(line));
+		}
+
+		assertEquals(8, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14"), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
+	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
@@ -26,7 +26,8 @@ public class SpoonConverterTest {
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
-		config.setClasspath(dep1 + File.separator + dep2);
+		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();
+		config.setClasspath(dep1 + File.pathSeparatorChar + dep2 + File.pathSeparatorChar + dep3);
 	}
 
 	@After


### PR DESCRIPTION
The JUnit5 implementation itself is just switching the JacocoRunner according to the setting. (Closes #10)

This PR contains mostly tests, which are meant to be used as the baseline when implementing #4, since we will have a faster flacoco and will also need the tests to assert behavioral neutrality.