### PR TITLE
Implement the new test-runner's API usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,15 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 
+	<repositories>
+		<repository>
+			<id>snapshots-repo</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<releases><enabled>false</enabled></releases>
+			<snapshots><enabled>true</enabled></snapshots>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -38,13 +47,11 @@
 			<version>2.3.1-SNAPSHOT</version>
 		</dependency>
 
-
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>
 			<version>1.2.17</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>fr.spoonlabs.flacoco.FlacocoMain</mainClass>
+						</manifest>
+					</archive>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,45 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.7</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.jacoco</groupId>
+			<artifactId>org.jacoco.core</artifactId>
+			<version>0.7.9</version>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
+			<version>4.13.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>5.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>5.3.2</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 		<dependency>
 			<groupId>eu.stamp-project</groupId>
 			<artifactId>test-runner</artifactId>
-			<version>2.3.0</version>
+			<version>2.3.1-SNAPSHOT</version>
 		</dependency>
 
 

--- a/src/main/java/fr/spoonlabs/flacoco/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/FlacocoMain.java
@@ -1,9 +1,5 @@
 package fr.spoonlabs.flacoco;
 
-import java.io.File;
-import java.util.Map;
-import java.util.concurrent.Callable;
-
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumRunner;
@@ -11,9 +7,16 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
 @Command(name = "FlacocoMain", mixinStandardHelpOptions = true, version = "0.0.1", description = "Flacoco: fault localization")
 public class FlacocoMain implements Callable<Integer> {
 	static boolean log = true;
+
+	@Option(names = { "-w", "--workspace"}, description = "Path to the workspace directory of flacoco.", defaultValue = "./")
+	String workspace;
 
 	@Option(names = { "-p", "--projectpath" }, description = "Path to the project to analyze.")
 	String projectPath = null;
@@ -23,6 +26,15 @@ public class FlacocoMain implements Callable<Integer> {
 
 	@Option(names = { "-c", "--classpath" }, description = "Classpath of the project under analyzis.")
 	String classpath;
+
+	@Option(names = { "--junitClasspath" }, description = "Classpath to junit dependencies")
+	String customJUnitClasspath;
+
+	@Option(names = { "--jacocoClasspath" }, description = "Classpath to jacoco dependencies")
+	String customJacocoClasspath;
+
+	@Option(names = { "--mavenHome" }, description = "Path to maven home")
+	String mavenHome;
 
 	@Option(names = {
 			"--coverTest" }, description = "Indicates if coverage must also cover the tests.", defaultValue = "false")
@@ -44,13 +56,20 @@ public class FlacocoMain implements Callable<Integer> {
 	}
 
 	@Override
-	public Integer call() throws Exception {
+	public Integer call() {
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(new File(this.workspace).getAbsolutePath());
 		config.setProjectPath(new File(this.projectPath).getAbsolutePath());
 
 		if (this.classpath != null && !this.classpath.trim().isEmpty())
 			config.setClasspath(classpath);
+		if (this.customJUnitClasspath != null && !this.customJUnitClasspath.trim().isEmpty())
+			config.setCustomJacocoClasspath(this.customJUnitClasspath);
+		if (this.customJacocoClasspath != null && !this.customJacocoClasspath.trim().isEmpty())
+			config.setCustomJacocoClasspath(this.customJacocoClasspath);
+		if (this.mavenHome != null && !this.mavenHome.trim().isEmpty())
+			config.setMavenHome(this.mavenHome);
 
 		config.setCoverTests(coverTest);
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -25,8 +25,11 @@ public class FlacocoConfig {
 	private String workspace;
 	private String projectPath;
 	private String classpath;
+	private String customJUnit4Classpath;
+	private String customJUnit5Classpath;
 	private TestFramework testFramework;
 	private boolean coverTests;
+
 
 	private FaultLocalizationFamily family;
 	//------Options for spectrum-based fault localization------
@@ -47,6 +50,8 @@ public class FlacocoConfig {
 		this.workspace = new File("./").getAbsolutePath();
 		this.projectPath = new File("./").getAbsolutePath();
 		this.classpath = new File("./").getAbsolutePath();
+		this.customJUnit4Classpath = null;
+		this.customJUnit5Classpath = null;
 		this.testFramework = TestFramework.JUNIT4;
 		this.coverTests = false;
 
@@ -76,6 +81,22 @@ public class FlacocoConfig {
 
 	public void setClasspath(String classpath) {
 		this.classpath = classpath;
+	}
+
+	public String getCustomJUnit4Classpath() {
+		return customJUnit4Classpath;
+	}
+
+	public void setCustomJUnit4Classpath(String customJUnit4Classpath) {
+		this.customJUnit4Classpath = customJUnit4Classpath;
+	}
+
+	public String getCustomJUnit5Classpath() {
+		return customJUnit5Classpath;
+	}
+
+	public void setCustomJUnit5Classpath(String customJUnit5Classpath) {
+		this.customJUnit5Classpath = customJUnit5Classpath;
 	}
 
 	public TestFramework getTestFramework() {

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -25,8 +25,9 @@ public class FlacocoConfig {
 	private String workspace;
 	private String projectPath;
 	private String classpath;
-	private String customJUnit4Classpath;
-	private String customJUnit5Classpath;
+	private String customJUnitClasspath;
+	private String customJacocoClasspath;
+	private String mavenHome;
 	private TestFramework testFramework;
 	private boolean coverTests;
 
@@ -50,8 +51,9 @@ public class FlacocoConfig {
 		this.workspace = new File("./").getAbsolutePath();
 		this.projectPath = new File("./").getAbsolutePath();
 		this.classpath = new File("./").getAbsolutePath();
-		this.customJUnit4Classpath = null;
-		this.customJUnit5Classpath = null;
+		this.customJUnitClasspath = null;
+		this.customJacocoClasspath = null;
+		this.mavenHome = System.getProperty("user.home") + "/.m2/repository/";
 		this.testFramework = TestFramework.JUNIT4;
 		this.coverTests = false;
 
@@ -83,20 +85,28 @@ public class FlacocoConfig {
 		this.classpath = classpath;
 	}
 
-	public String getCustomJUnit4Classpath() {
-		return customJUnit4Classpath;
+	public String getCustomJUnitClasspath() {
+		return customJUnitClasspath;
 	}
 
-	public void setCustomJUnit4Classpath(String customJUnit4Classpath) {
-		this.customJUnit4Classpath = customJUnit4Classpath;
+	public void setCustomJUnitClasspath(String customJUnitClasspath) {
+		this.customJUnitClasspath = customJUnitClasspath;
 	}
 
-	public String getCustomJUnit5Classpath() {
-		return customJUnit5Classpath;
+	public String getCustomJacocoClasspath() {
+		return customJacocoClasspath;
 	}
 
-	public void setCustomJUnit5Classpath(String customJUnit5Classpath) {
-		this.customJUnit5Classpath = customJUnit5Classpath;
+	public void setCustomJacocoClasspath(String customJacocoClasspath) {
+		this.customJacocoClasspath = customJacocoClasspath;
+	}
+
+	public String getMavenHome() {
+		return mavenHome;
+	}
+
+	public void setMavenHome(String mavenHome) {
+		this.mavenHome = mavenHome;
 	}
 
 	public TestFramework getTestFramework() {
@@ -137,6 +147,7 @@ public class FlacocoConfig {
 				"workspace='" + workspace + '\'' +
 				", projectPath='" + projectPath + '\'' +
 				", classpath='" + classpath + '\'' +
+				", customJUnitClasspath='" + customJUnitClasspath + '\'' +
 				", testFramework=" + testFramework +
 				", coverTests=" + coverTests +
 				", family=" + family +

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageFromSingleTestUnit.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageFromSingleTestUnit.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.core.coverage;
 
 import eu.stamp_project.testrunner.listener.Coverage;
+import eu.stamp_project.testrunner.listener.impl.CoverageDetailed;
 
 /**
  * Contains the results of the execution of a single test case (i.e., a method).
@@ -20,7 +21,7 @@ public class CoverageFromSingleTestUnit {
 	/**
 	 * Coverage info
 	 */
-	protected Coverage cov;
+	protected CoverageDetailed cov;
 	/**
 	 * Result of the execution: true if it's passing
 	 */
@@ -30,7 +31,7 @@ public class CoverageFromSingleTestUnit {
 	 */
 	protected boolean isSkip = false;
 
-	public CoverageFromSingleTestUnit(String testClass, String method, Coverage cov) {
+	public CoverageFromSingleTestUnit(String testClass, String method, CoverageDetailed cov) {
 		super();
 		this.testClass = testClass;
 		this.testMethod = method;
@@ -49,7 +50,7 @@ public class CoverageFromSingleTestUnit {
 		return cov;
 	}
 
-	public void setCov(Coverage cov) {
+	public void setCov(CoverageDetailed cov) {
 		this.cov = cov;
 	}
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -4,7 +4,6 @@ import eu.stamp_project.testrunner.EntryPoint;
 import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
 import eu.stamp_project.testrunner.listener.impl.CoverageDetailed;
 import eu.stamp_project.testrunner.runner.ParserOptions;
-import eu.stamp_project.testrunner.utils.ConstantsHelper;
 import fr.spoonlabs.flacoco.api.Flacoco;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.test.TestInformation;
@@ -112,38 +111,34 @@ public class CoverageRunner {
 	 */
 	private String computeClasspath() {
 		String classpath = this.config.getClasspath();
+		String mavenHome = this.config.getMavenHome();
+		String junitClasspath;
+		String jacocoClassPath;
 
-		String MAVEN_HOME = System.getProperty("user.home") + "/.m2/repository/";
-		String JUNIT4_CP;
-		String JUNIT5_CP;
-		String JACOCO_CP;
+		junitClasspath = mavenHome + "junit/junit/4.12/junit-4.12.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-commons/1.3.2/junit-platform-commons-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-engine/1.3.2/junit-platform-engine-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
 
-		JUNIT4_CP = MAVEN_HOME + "junit/junit/4.12/junit-4.12.jar" + ConstantsHelper.PATH_SEPARATOR
-				+ MAVEN_HOME + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar";
-		JUNIT5_CP =
-				MAVEN_HOME + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/junit/platform/junit-platform-commons/1.3.2/junit-platform-commons-1.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/junit/platform/junit-platform-engine/1.3.2/junit-platform-engine-1.3.2.jar" + ConstantsHelper.PATH_SEPARATOR
-						+ MAVEN_HOME + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
-		JACOCO_CP = MAVEN_HOME + "org/jacoco/org.jacoco.core/0.8.3/org.jacoco.core-0.7.9.jar";
-
-		// Add Jacoco dependency
-		classpath += File.pathSeparatorChar + JACOCO_CP + File.pathSeparatorChar + MAVEN_HOME + MAVEN_HOME + "commons-io/commons-io/2.5/commons-io-2.5.jar";
+		jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.3/org.jacoco.core-0.7.9.jar";
 
 		// Add JUnit dependencies
-		if (this.config.getCustomJUnit4Classpath() != null) {
-			classpath += File.pathSeparatorChar + this.config.getCustomJUnit4Classpath();
+		if (this.config.getCustomJUnitClasspath() != null) {
+			classpath += File.pathSeparatorChar + this.config.getCustomJUnitClasspath();
 		} else {
-			classpath += File.pathSeparatorChar + JUNIT4_CP;
+			classpath += File.pathSeparatorChar + junitClasspath;
 		}
-		if (this.config.getCustomJUnit5Classpath() != null) {
-			classpath += File.pathSeparatorChar + this.config.getCustomJUnit5Classpath();
+		// Add jacoco dependency
+		if (this.config.getCustomJacocoClasspath() != null) {
+			classpath += File.pathSeparatorChar + this.config.getCustomJacocoClasspath();
 		} else {
-			classpath += File.pathSeparatorChar + JUNIT5_CP;
+			classpath += File.pathSeparatorChar + jacocoClassPath;
 		}
 
 		return classpath;

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -91,6 +91,7 @@ public class CoverageRunner {
 	 */
 	private void setupTestRunnerEntryPoint() {
 		EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.DETAIL;
+		EntryPoint.verbose = true;
 		// test-runner requires a flag when using JUnit5
 		if (this.config.getTestFramework().equals(FlacocoConfig.TestFramework.JUNIT5)) {
 			EntryPoint.jUnit5Mode = true;

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -97,6 +97,8 @@ public class CoverageRunner {
 		// test-runner requires a flag when using JUnit5
 		if (this.config.getTestFramework().equals(FlacocoConfig.TestFramework.JUNIT5)) {
 			EntryPoint.jUnit5Mode = true;
+		} else {
+			EntryPoint.jUnit5Mode = false;
 		}
 		if (this.config.isCoverTests()) {
 			throw new UnsupportedOperationException();

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -1,19 +1,17 @@
 package fr.spoonlabs.flacoco.core.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
-import eu.stamp_project.testrunner.listener.CoveredTestResult;
-import eu.stamp_project.testrunner.listener.impl.CoverageCollectorDetailed;
-import eu.stamp_project.testrunner.runner.coverage.JUnit4JacocoRunner;
-import eu.stamp_project.testrunner.runner.coverage.JUnit5JacocoRunner;
-import eu.stamp_project.testrunner.runner.coverage.JacocoRunner;
+import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
+import eu.stamp_project.testrunner.listener.impl.CoverageDetailed;
+import eu.stamp_project.testrunner.runner.ParserOptions;
 import fr.spoonlabs.flacoco.api.Flacoco;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.test.TestInformation;
 import org.apache.log4j.Logger;
 
 import java.io.File;
-import java.net.URLClassLoader;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Class for running the coverage runner from test-runner and computing
@@ -27,8 +25,6 @@ public class CoverageRunner {
 	private FlacocoConfig config = FlacocoConfig.getInstance();
 
 	public CoverageMatrix getCoverageMatrix(List<TestInformation> testToRun) {
-		setupTestRunnerEntryPoint();
-
 		// This matrix stores the results: the execution of tests and the coverage of
 		// that execution on each line
 		CoverageMatrix matrixExecutionResult = new CoverageMatrix();
@@ -39,60 +35,53 @@ public class CoverageRunner {
 		String pathToTestClasses = new File(this.config.getProjectPath() + File.separator + "target/test-classes/")
 				.getAbsolutePath();
 
-		// Get JacocoRunner
-		JacocoRunner runner = getJacocoRunner(pathToClasses, pathToTestClasses);
-		URLClassLoader urlloader = runner.getUrlClassloaderFromClassPath(this.config.getClasspath());
-
-		int i = 0;
 		// For each test class:
 		for (TestInformation testTuple : testToRun) {
 
-			logger.debug("#Test " + i++ + " / " + testToRun.size() + " " + testTuple.getTestClassQualifiedName() + " "
-					+ testTuple.getTestMethods().size());
+			this.logger.debug("-----");
+			this.logger.debug("Calling class " + testTuple.getTestClassQualifiedName());
 
-			// For each method test
-			for (String method : testTuple.getTestMethodsNames()) {
+			this.logger.debug("Classpath " + this.config.getClasspath());
+			this.logger.debug("classesDirectory" + pathToClasses);
+			this.logger.debug("testClassesDirectory" + pathToTestClasses);
+			this.logger.debug("test class to run : " + testTuple.getTestClassQualifiedName());
+			this.logger.debug("test methods to run : " + testTuple.getTestMethodsNames());
 
-				logger.debug("-----");
-				logger.debug("Calling method " + method);
+			try {
+				setupTestRunnerEntryPoint();
+				CoveredTestResultPerTestMethod result = EntryPoint.runCoveredTestResultPerTestMethods(
+						this.config.getClasspath(),
+						pathToClasses + File.pathSeparatorChar + pathToTestClasses,
+						testTuple.getTestClassQualifiedName(),
+						testTuple.getTestMethodsNames().toArray(new String[0])
+				);
 
-				logger.debug("Classpath " + this.config.getClasspath());
-
-				logger.debug("classesDirectory" + pathToClasses);
-				logger.debug("testClassesDirectory" + pathToTestClasses);
-				logger.debug("test class to run : " + testTuple.getTestClassQualifiedName());
-				logger.debug("test method to run : " + method);
-
-				// We run the instrumented classes
-				if (this.config.isCoverTests()) {
-					runner.instrumentAll(pathToTestClasses);
-				}
-				CoveredTestResult coverageResult = runner.run(new CoverageCollectorDetailed(), urlloader,
-						pathToClasses, pathToTestClasses, testTuple.getTestClassQualifiedName(), this.config.isCoverTests(),
-						new String[]{method});
-
-				if (coverageResult == null)
+				if (result == null) {
+					this.logger.error("Got a null result for test class: " + testTuple.getTestClassQualifiedName());
 					continue;
-
-				CoverageFromSingleTestUnit coverageFromSingleTestWrapper = new CoverageFromSingleTestUnit(
-						testTuple.getTestClassQualifiedName(), method, coverageResult.getCoverageInformation());
-
-				CoveredTestResult tr = (CoveredTestResult) coverageResult;
-
-				boolean isPassing = tr.getPassingTests().size() > 0 && tr.getFailingTests().size() == 0;
-				coverageFromSingleTestWrapper.setIsPassing(isPassing);
-
-				boolean isSkip = tr.getIgnoredTests().size() > 0 || tr.getAssumptionFailingTests().size() > 0;
-				if (isSkip) {
-					coverageFromSingleTestWrapper.setIsSkip(isSkip);
-				} else {
-					coverageFromSingleTestWrapper.setIsSkip(false);
 				}
 
-				matrixExecutionResult.processSingleTest(coverageFromSingleTestWrapper);
+				this.logger.debug(result);
 
+				// Process each method individually
+				for (String method : testTuple.getTestMethodsNames()) {
+					CoverageFromSingleTestUnit coverageFromSingleTestWrapper = new CoverageFromSingleTestUnit(
+							testTuple.getTestClassQualifiedName(),
+							method,
+							(CoverageDetailed) result.getCoverageOf(method)
+					);
+
+					boolean isPassing = result.getPassingTests().contains(method) && !result.getFailingTests().contains(method);
+					coverageFromSingleTestWrapper.setIsPassing(isPassing);
+					boolean isSkip = result.getIgnoredTests().contains(method) || result.getFailingTests().contains(method);
+					coverageFromSingleTestWrapper.setIsSkip(isSkip);
+
+					matrixExecutionResult.processSingleTest(coverageFromSingleTestWrapper);
+				}
+
+			} catch (TimeoutException e) {
+				this.logger.error(e);
 			}
-
 		}
 		return matrixExecutionResult;
 	}
@@ -101,20 +90,14 @@ public class CoverageRunner {
 	 * Auxiliary method to setup test-runners entry point
 	 */
 	private void setupTestRunnerEntryPoint() {
+		EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.DETAIL;
 		// test-runner requires a flag when using JUnit5
 		if (this.config.getTestFramework().equals(FlacocoConfig.TestFramework.JUNIT5)) {
 			EntryPoint.jUnit5Mode = true;
 		}
-	}
-
-	private JacocoRunner getJacocoRunner(String sourceClasses, String testClasses) {
-		switch (this.config.getTestFramework()) {
-			case JUNIT4:
-				return new JUnit4JacocoRunner(sourceClasses, testClasses, new CoverageCollectorDetailed());
-			case JUNIT5:
-				return new JUnit5JacocoRunner(sourceClasses, testClasses, new CoverageCollectorDetailed());
-			default:
-				return null;
+		if (this.config.isCoverTests()) {
+			throw new UnsupportedOperationException();
 		}
 	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/FlacocoMainTest.java
@@ -4,6 +4,8 @@ import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.junit.Test;
 
+import java.io.File;
+
 import static org.junit.Assert.fail;
 
 public class FlacocoMainTest {
@@ -12,9 +14,22 @@ public class FlacocoMainTest {
 	public void testMainExplicitArguments() throws Exception {
 
 		// It's a smoke test
+		String mavenHome = System.getProperty("user.home") + "/.m2/repository/";
+		String junitClasspath = mavenHome + "junit/junit/4.12/junit-4.12.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-commons/1.3.2/junit-platform-commons-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-engine/1.3.2/junit-platform-engine-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
+		String jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.3/org.jacoco.core-0.7.9.jar";
 
 		FlacocoMain.main(new String[]{"--projectpath", "examples/exampleFL1/FLtest1", "--formula",
-				SpectrumFormula.OCHIAI.name(), "--coverTest", "--framework", FlacocoConfig.TestFramework.JUNIT4.name()
+				SpectrumFormula.OCHIAI.name(), "--framework", FlacocoConfig.TestFramework.JUNIT4.name(),
+				"--mavenHome", mavenHome, "--junitClasspath", junitClasspath, "--jacocoClasspath", jacocoClassPath
 
 		});
 	}

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -4,16 +4,12 @@ import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -24,11 +20,15 @@ import static org.junit.Assert.assertTrue;
  */
 public class FlacocoTest {
 
+	@Rule
+	public TemporaryFolder workspaceDir = new TemporaryFolder();
+
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
 		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();
@@ -36,7 +36,7 @@ public class FlacocoTest {
 	}
 
 	@After
-	public void tearDown() throws IOException {
+	public void tearDown() {
 		FlacocoConfig.deleteInstance();
 	}
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -9,7 +9,6 @@ import org.junit.rules.TemporaryFolder;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -24,7 +23,7 @@ public class FlacocoTest {
 	public TemporaryFolder workspaceDir = new TemporaryFolder();
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -6,10 +6,14 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -32,7 +36,7 @@ public class FlacocoTest {
 	}
 
 	@After
-	public void tearDown() {
+	public void tearDown() throws IOException {
 		FlacocoConfig.deleteInstance();
 	}
 
@@ -54,7 +58,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -65,8 +69,6 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	/**
@@ -91,7 +93,7 @@ public class FlacocoTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(7, susp.keySet().size());
+		assertEquals(5, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21"), 0);
@@ -103,8 +105,6 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0.01);
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class FlacocoTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(7, susp.keySet().size());
+		assertEquals(5, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21"), 0);
@@ -137,11 +137,10 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0.01);
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL1SpectrumBasedOchiaiCoverTestsDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -160,7 +159,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -173,8 +172,6 @@ public class FlacocoTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
@@ -191,9 +188,7 @@ public class FlacocoTest {
 		// Run default mode
 		Map<CtStatement, Double> susp = flacoco.runSpoon();
 
-		// Fails because two original keys get mapped to the same CtStatement
-		//assertEquals(6, susp.size());
-		assertEquals(5, susp.size());
+		assertEquals(4, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
@@ -214,7 +209,6 @@ public class FlacocoTest {
 					break;
 				// Lines executed by all test
 				case 10:
-				case 5:
 					assertEquals(0.5, susp.get(ctStatement), 0);
 					break;
 			}
@@ -240,7 +234,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -251,11 +245,10 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiCoverTestsDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -275,7 +268,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -288,8 +281,6 @@ public class FlacocoTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
@@ -307,9 +298,7 @@ public class FlacocoTest {
 		// Run default mode
 		Map<CtStatement, Double> susp = flacoco.runSpoon();
 
-		// Fails because two original keys get mapped to the same CtStatement
-		//assertEquals(6, susp.size());
-		assertEquals(5, susp.size());
+		assertEquals(4, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
@@ -330,7 +319,6 @@ public class FlacocoTest {
 					break;
 				// Lines executed by all test
 				case 10:
-				case 5:
 					assertEquals(0.5, susp.get(ctStatement), 0);
 					break;
 			}

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -9,7 +9,6 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -5,12 +5,11 @@ import fr.spoonlabs.flacoco.core.test.TestDetector;
 import fr.spoonlabs.flacoco.core.test.TestInformation;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -19,11 +18,15 @@ import static org.junit.Assert.*;
 
 public class CoverageRunnerTest {
 
+	@Rule
+	public TemporaryFolder workspaceDir = new TemporaryFolder();
+
 	@Before
 	public void setUp() {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
 		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -7,6 +7,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -54,8 +55,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 10 executed lines
-		assertEquals(10, matrix.getResultExecution().keySet().size());
+		// 8 executed lines
+		assertEquals(8, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<Integer> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -155,8 +156,8 @@ public class CoverageRunnerTest {
 		assertEquals(1, matrix.getFailingTestCases().size());
 		assertEquals(5, matrix.getTests().size());
 
-		// 10 executed lines
-		assertEquals(11, matrix.getResultExecution().keySet().size());
+		// 9 executed lines
+		assertEquals(9, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<Integer> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
@@ -188,8 +189,8 @@ public class CoverageRunnerTest {
 		assertEquals(1, matrix.getFailingTestCases().size());
 		assertEquals(5, matrix.getTests().size());
 
-		// 10 executed lines
-		assertEquals(11, matrix.getResultExecution().keySet().size());
+		// 9 executed lines
+		assertEquals(9, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<Integer> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
@@ -205,6 +206,7 @@ public class CoverageRunnerTest {
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL1CoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -225,9 +227,9 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 18 executed lines
-		// We have 10 from class under test + 8 from test
-		assertEquals(18, matrix.getResultExecution().keySet().size());
+		// 16 executed lines
+		// We have 8 from class under test + 8 from test
+		assertEquals(16, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<Integer> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -240,7 +242,7 @@ public class CoverageRunnerTest {
 		config.setCoverTests(false);
 		matrix = detector.getCoverageMatrix(tests);
 
-		assertEquals(10, matrix.getResultExecution().keySet().size());
+		assertEquals(8, matrix.getResultExecution().keySet().size());
 	}
 
 	@Test
@@ -264,8 +266,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 10 executed lines
-		assertEquals(10, matrix.getResultExecution().keySet().size());
+		// 8 executed lines
+		assertEquals(8, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<Integer> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -5,9 +5,12 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -17,11 +20,15 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestDetectorTest {
 
+	@Rule
+	public TemporaryFolder workspaceDir = new TemporaryFolder();
+
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
 		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -24,7 +23,7 @@ public class TestDetectorTest {
 	public TemporaryFolder workspaceDir = new TemporaryFolder();
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -5,6 +5,7 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -45,7 +46,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -56,8 +57,6 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
@@ -75,7 +74,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(7, susp.size());
+		assertEquals(5, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21"), 0);
@@ -87,8 +86,6 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0.01);
 	}
 
 	@Test
@@ -106,7 +103,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(7, susp.size());
+		assertEquals(5, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21"), 0);
@@ -118,11 +115,10 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0.01);
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL1OchiaiCoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -138,7 +134,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -151,8 +147,6 @@ public class SpectrumRunnerTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
@@ -171,7 +165,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -182,11 +176,10 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL4JUnit5OchiaiCoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -203,7 +196,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15"), 0);
@@ -216,8 +209,6 @@ public class SpectrumRunnerTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7"), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5"), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6"), 0);
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -3,23 +3,26 @@ package fr.spoonlabs.flacoco.localization.spectrum;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
 public class SpectrumRunnerTest {
 
+	@Rule
+	public TemporaryFolder workspaceDir = new TemporaryFolder();
+
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
 		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -7,7 +7,6 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -18,7 +17,7 @@ public class SpectrumRunnerTest {
 	public TemporaryFolder workspaceDir = new TemporaryFolder();
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
@@ -4,13 +4,12 @@ import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.utils.spoon.SpoonConverter;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,11 +18,15 @@ import static org.junit.Assert.assertTrue;
 
 public class SpoonConverterTest {
 
+	@Rule
+	public TemporaryFolder workspaceDir = new TemporaryFolder();
+
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
 		String dep1 = new File("./examples/libs/junit-4.12.jar").getAbsolutePath();
 		String dep2 = new File("./examples/libs/hamcrest-core-1.3.jar").getAbsolutePath();
 		String dep3 = new File("./examples/libs/junit-jupiter-api-5.7.2.jar").getAbsolutePath();

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpoonConverterTest.java
@@ -9,7 +9,6 @@ import org.junit.rules.TemporaryFolder;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -22,7 +21,7 @@ public class SpoonConverterTest {
 	public TemporaryFolder workspaceDir = new TemporaryFolder();
 
 	@Before
-	public void setUp() throws IOException {
+	public void setUp() {
 		LogManager.getRootLogger().setLevel(Level.DEBUG);
 
 		FlacocoConfig config = FlacocoConfig.getInstance();


### PR DESCRIPTION
This PR implements the usage of the new `test-runner`'s API.

On important aspect is that the `CoverageCollectorDetailed` transformer doesn't consider constructor coverage (See https://github.com/STAMP-project/test-runner/blob/5b84d1a940564a1c1ee0b22b695503fab4600d97/src/main/java/eu/stamp_project/testrunner/listener/impl/CoverageCollectorDetailed.java#L45-L52), so I have modified the existing tests to follow that.

Also, `test-runner` doesn't support test coverage by default, so to support that we need to implement it in `EntryPoint` as an option too.

I'm not entirely sure this is what we want to do tho, as some constructors may have bugs and the coverage there will be important. WDYT?