### PR TITLE
Fix deploy workflow guard

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -1,9 +1,9 @@
 name: deploy-snapshot
 
 on:
-  workflow_run:
-    workflows: ["tests"]
-    types: [completed]
+  push:
+    branches:
+      - master
 
 jobs:
   deploy-on-success:


### PR DESCRIPTION
The deployment workflow was running even on PR.

This PR fixes it, introducing a guard so that it only runs on the `master` branch.