### PR TITLE
Fix deploy workflow guard again

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -6,10 +6,7 @@ on:
       - master
 
 jobs:
-  deploy-on-success:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-
+  deploy-snapshot:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4


### PR DESCRIPTION
I really wish there was a way of testing `workflow_run` outside of the main branch 