### PR TITLE
Fix issues with `test-runner` usage.

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
@@ -65,8 +65,8 @@ public class FlacocoMain implements Callable<Integer> {
 	@Option(names = {"--testRunnerVerbose"}, description = "Test-runner verbose mode.", defaultValue = "false")
 	boolean testRunnerVerbose = false;
 
-	@Option(names = {"--testRunnerTimeoutInMs"}, description = "Timeout for each test execution with test-runner.", defaultValue = "10000")
-	int testRunnerTimeoutInMs = 10000;
+	@Option(names = {"--testRunnerTimeoutInMs"}, description = "Timeout for each test execution with test-runner. Must be greater than 0. Default value is 1000000", defaultValue = "1000000")
+	int testRunnerTimeoutInMs = 1000000;
 
 	@Option(names = {"--testRunnerJVMArgs"}, description = "JVM args for test-runner's test execution VMs.")
 	String testRunnerJVMArgs = null;
@@ -149,6 +149,8 @@ public class FlacocoMain implements Callable<Integer> {
 
 		config.setCoverTests(coverTest);
 		config.setTestRunnerVerbose(testRunnerVerbose);
+		if (this.testRunnerTimeoutInMs > 0)
+			config.setTestRunnerTimeoutInMs(this.testRunnerTimeoutInMs);
 		config.setTestRunnerTimeoutInMs(testRunnerTimeoutInMs);
 		if (this.testRunnerJVMArgs != null && !this.testRunnerJVMArgs.trim().isEmpty())
 			config.setTestRunnerJVMArgs(testRunnerJVMArgs);

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -65,7 +65,7 @@ public class FlacocoConfig {
 		this.mavenHome = System.getProperty("user.home") + "/.m2/repository/";
 		this.coverTests = false;
 		this.testRunnerVerbose = false;
-		this.testRunnerTimeoutInMs = 10000;
+		this.testRunnerTimeoutInMs = 1000000;
 		this.testRunnerJVMArgs = null;
 		this.threshold = 0.0;
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
@@ -23,7 +23,7 @@ public abstract class TestFrameworkStrategy {
 	 * Auxiliary method to setup test-runners default options
 	 */
 	protected void setupTestRunnerEntryPoint() {
-		EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.DETAIL;
+		EntryPoint.coverageDetail = ParserOptions.CoverageTransformerDetail.DETAIL_COMPRESSED;
 		EntryPoint.workingDirectory = new File(this.config.getWorkspace());
 		EntryPoint.verbose = this.config.isTestRunnerVerbose();
 		EntryPoint.timeoutInMs = this.config.getTestRunnerTimeoutInMs();


### PR DESCRIPTION
- Increase default timeout. The default one was too low for reasonably sized projects.
- Change coverage detail to compressed detailed, so as to use less memory.

Requires https://github.com/STAMP-project/test-runner/pull/110.