### PR TITLE
Fix spectrum suspicious computation

### DIFF
--- a/.github/install_examples.sh
+++ b/.github/install_examples.sh
@@ -9,6 +9,7 @@ mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler
 mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL5JUnit3/FLtest1/
 mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL6Mixed/FLtest1/
 mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL7SameNamedMethods/FLtest1/
+mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL11/FLtest1/
 
 # Copy compiled classes to non-maven mirror projects
 rm -r examples/exampleFL8NotMaven/bin/

--- a/examples/exampleFL11/FLtest1/pom.xml
+++ b/examples/exampleFL11/FLtest1/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>fr.spoonlabs</groupId>
+  <artifactId>FLtest1</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>FLtest1</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/examples/exampleFL11/FLtest1/src/main/java/fr/spoonlabs/FLtest1/Calculator.java
+++ b/examples/exampleFL11/FLtest1/src/main/java/fr/spoonlabs/FLtest1/Calculator.java
@@ -1,0 +1,23 @@
+package fr.spoonlabs.FLtest1;
+
+public class Calculator {
+
+	public Calculator() {
+	}
+
+	public int calculate(String op, int op1, int op2) {
+
+		if (op.equals("+")) {
+			return op1 + op2;
+		} else if (op.equals("-")) {
+			return op1 - op2;
+		} else if (op.equals("*")) {
+			return op1 / op2;//buggy
+		} else if (op.equals("/")) {
+			return op1 * op2;//buggy
+		} else if (op.equals("%")) {
+			return op1 % op2;
+		}
+		throw new UnsupportedOperationException(op);
+	}
+}

--- a/examples/exampleFL11/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
+++ b/examples/exampleFL11/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
@@ -1,0 +1,39 @@
+package fr.spoonlabs.FLtest1;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class CalculatorTest {
+
+	Calculator c = new Calculator();
+
+	@Test
+	public void testSum() {
+
+		assertEquals(4, c.calculate("+", 3, 1));
+
+	}
+
+	@Test
+	public void testSubs() {
+
+		assertEquals(2, c.calculate("-", 3, 1));
+
+	}
+
+	@Test
+	public void testMul() {
+
+		assertEquals(8, c.calculate("*", 4, 2));
+
+	}
+
+	@Test
+	public void testDiv() {
+
+		assertEquals(2, c.calculate("/", 12, 6));
+
+	}
+
+}

--- a/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
@@ -21,27 +21,13 @@ public class SpectrumSuspiciousComputation {
 	private FlacocoConfig config = FlacocoConfig.getInstance();
 
 	/**
-	 * @param matrix  matrix with the coverage
-	 * @param formula the formula to compute the suspiciousness
+	 * @param matrix                        matrix with the coverage
+	 * @param formula                       the formula to compute the
+	 *                                      suspiciousness
 	 * @return a map where the keys are the lines and the values are the suspicious
 	 * values
 	 */
 	public Map<String, Suspiciousness> calculateSuspicious(CoverageMatrix matrix, Formula formula) {
-		return calculateSuspicious(matrix, formula, false);
-	}
-
-	/**
-	 * @param matrix                        matrix with the coverage
-	 * @param formula                       the formula to compute the
-	 *                                      suspiciousness
-	 * @param includeSuspiciousEqualsToZero indicates if the suspicious list
-	 *                                      contains lines with suspicious equals to
-	 *                                      zero
-	 * @return a map where the keys are the lines and the values are the suspicious
-	 * values
-	 */
-	public Map<String, Suspiciousness> calculateSuspicious(CoverageMatrix matrix, Formula formula,
-	                                                       boolean includeSuspiciousEqualsToZero) {
 
 		Map<String, Suspiciousness> result = new HashMap<>();
 		// For each line of code to analyze
@@ -66,7 +52,7 @@ public class SpectrumSuspiciousComputation {
 				} else if (iTestPassing && !nrExecuted) {
 					nrTestPassingNotExecuting++;
 				} else if (!iTestPassing && !nrExecuted) {
-					nrTestPassingNotExecuting++;
+					nrTestFailingNotExecuting++;
 				}
 			}
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -913,4 +913,39 @@ public class FlacocoTest {
 		}
 	}
 
+	@Test
+	public void testExampleFL11SpectrumBasedOchiaiDefaultMode() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL11/FLtest1").getAbsolutePath());
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<String, Suspiciousness> susp = flacoco.runDefault();
+
+		for (String line : susp.keySet()) {
+			System.out.println("" + line + " " + susp.get(line));
+		}
+
+		assertEquals(6, susp.size());
+
+		// Line executed by all failing test cases
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
+
+		// Line executed by one passing and 2 failing tests
+		assertEquals(0.81, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+
+		// Lines executed by one failing test
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0.01);
+
+		// Line executed by all tests (2 passing, 2 failing)
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
+	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -959,4 +959,101 @@ public class CoverageRunnerTest {
 		assertNull(modCond);
 	}
 
+	@Test
+	public void testExampleFL11() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL11/FLtest1").getAbsolutePath());
+
+		CoverageRunner detector = new CoverageRunner();
+
+		// Find the tests
+		TestDetector testDetector = new TestDetector();
+		List<TestContext> tests = testDetector.getTests();
+
+		assertTrue(tests.size() > 0);
+
+		CoverageMatrix matrix = detector.getCoverageMatrix(tests);
+
+		// verify nr of test
+		assertEquals(4, matrix.getTests().size());
+		assertEquals(2, matrix.getFailingTestCases().size());
+
+		// 8 executed lines
+		assertEquals(8, matrix.getResultExecution().keySet().size());
+
+		// This line is the first if, so it's covered by all tests
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+
+		assertEquals(4, firstLineExecuted.size());
+
+		Set<String> executedTestKeys = firstLineExecuted.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
+
+		// This one is only executed by the sum
+		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+
+		executedTestKeys = returnSum.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+
+		assertEquals(1, returnSum.size());
+
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+
+		// This line is the second if, so it's covered by all tests, except the first one
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		assertEquals(3, secondIfExecuted.size());
+
+		executedTestKeys = secondIfExecuted.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+
+		// The first one returns before
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
+
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		assertEquals(2, oneMultCond.size());
+		executedTestKeys = oneMultCond.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
+
+		// This line is inside one if, so it's executed only one
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		assertEquals(1, oneReturnLineExecuted.size());
+
+		executedTestKeys = oneReturnLineExecuted.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
+
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		assertEquals(1, divisionCond.size());
+		executedTestKeys = divisionCond.stream()
+				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
+
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
+		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
+		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
+
+		// Any test executes that
+		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		assertNull(modCond);
+	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -346,4 +346,23 @@ public class TestDetectorTest {
 		assertTrue(testContext.getTestFrameworkStrategy() instanceof JUnit4Strategy);
 	}
 
+	@Test
+	public void testExampleFL11() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL11/FLtest1").getAbsolutePath());
+
+		// Find the tests
+		TestDetector testDetector = new TestDetector();
+		List<TestContext> testContexts = testDetector.getTests();
+
+		// Check that there is only one test context
+		assertEquals(1, testContexts.size());
+		// Check that there are 4 test methods in the test context
+		TestContext testContext = testContexts.get(0);
+		assertEquals(4, testContext.getTestMethods().size());
+		// Check that the correct test framework is set
+		assertTrue(testContext.getTestFrameworkStrategy() instanceof JUnit4Strategy);
+	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -423,4 +423,36 @@ public class SpectrumRunnerTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
 	}
 
+	@Test
+	public void testExampleFL11Ochiai() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL11/FLtest1").getAbsolutePath());
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+
+		SpectrumRunner runner = new SpectrumRunner();
+
+		Map<String, Suspiciousness> susp = runner.run();
+
+		for (String line : susp.keySet()) {
+			System.out.println("susp " + line + " " + susp.get(line));
+		}
+
+		assertEquals(6, susp.size());
+
+		// Line executed by all failing test cases
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
+
+		// Line executed by one passing and 2 failing tests
+		assertEquals(0.81, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+
+		// Lines executed by one failing test
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0.01);
+
+		// Line executed by all tests (2 passing, 2 failing)
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
+	}
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputationTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputationTest.java
@@ -26,11 +26,18 @@ public class SpectrumSuspiciousComputationTest {
 		for (int i = 0; i <= 4; i++) {
 			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, true);
 		}
-		// test@-@[1,6] are ran in a passing test case
+		// test@-@[1,6] are ran in a failing test case
 		testMethod = mock(TestMethod.class);
 		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test2");
 		when(testMethod.toString()).thenReturn("test2");
 		for (int i = 0; i <= 6; i++) {
+			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, false);
+		}
+		// test@-@[1,9] are ran in a failing test case
+		testMethod = mock(TestMethod.class);
+		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test4");
+		when(testMethod.toString()).thenReturn("test4");
+		for (int i = 0; i <= 9; i++) {
 			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, false);
 		}
 		// test@-@[1,5] are ran in a passing test case
@@ -52,19 +59,24 @@ public class SpectrumSuspiciousComputationTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(9, susp.size());
 
-		// Line executed only by the failing
+		// Line executed by all the failing test cases
 		assertEquals(1.0, susp.get("test@-@6").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("test@-@5").getScore(), 0.01);
+		assertEquals(0.81, susp.get("test@-@5").getScore(), 0.01);
+
+		// Lines executed by just one failing test
+		assertEquals(0.70, susp.get("test@-@9").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@8").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@7").getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.57, susp.get("test@-@4").getScore(), 0.01);
-		assertEquals(0.57, susp.get("test@-@3").getScore(), 0.01);
-		assertEquals(0.57, susp.get("test@-@2").getScore(), 0.01);
-		assertEquals(0.57, susp.get("test@-@1").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@4").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@3").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@2").getScore(), 0.01);
+		assertEquals(0.70, susp.get("test@-@1").getScore(), 0.01);
 	}
 
 }


### PR DESCRIPTION
- Fix spectrum suspicious computation. The counters of failing and passing test cases that didn't execute a line were misused.
- Add tests cases to cover bug, since the other tests didn't capture this behavior.