### PR TITLE
Fix threshold and add include zero option

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
@@ -72,8 +72,11 @@ public class FlacocoMain implements Callable<Integer> {
 	@Option(names = {"--testRunnerJVMArgs"}, description = "JVM args for test-runner's test execution VMs.")
 	String testRunnerJVMArgs = null;
 
-	@Option(names = {"--threshold"}, description = "Threshold for suspiciousness score. Flacoco will only return suspicious results with score > threshold.", defaultValue = "0.0")
+	@Option(names = {"--threshold"}, description = "Threshold for suspiciousness score. Flacoco will only return suspicious results with score >= threshold. Results with a score of 0 are only included if the -includeZeros flag is set.", defaultValue = "0.0")
 	double threshold = 0.0;
+
+	@Option(names = {"--includeZeros"}, description = "Flag for including lines with a suspiciousness sore of 0.", defaultValue = "false")
+	boolean includeZeros = false;
 
 	@Option(names = {"-o", "--output"},
 			description = "Path to the output file. If no path is provided but the flag is, the result will be stored in flacoco_result.{extension}",
@@ -173,6 +176,7 @@ public class FlacocoMain implements Callable<Integer> {
 		if (this.testRunnerJVMArgs != null && !this.testRunnerJVMArgs.trim().isEmpty())
 			config.setTestRunnerJVMArgs(testRunnerJVMArgs);
 		config.setThreshold(threshold);
+		config.setIncludeZero(includeZeros);
 
 		config.setjUnit4Tests(this.tests.jUnit4Tests);
 		config.setjUnit5Tests(this.tests.jUnit5Tests);

--- a/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
@@ -176,7 +176,7 @@ public class FlacocoMain implements Callable<Integer> {
 		if (this.testRunnerJVMArgs != null && !this.testRunnerJVMArgs.trim().isEmpty())
 			config.setTestRunnerJVMArgs(testRunnerJVMArgs);
 		config.setThreshold(threshold);
-		config.setIncludeZero(includeZeros);
+		config.setIncludeZeros(includeZeros);
 
 		config.setjUnit4Tests(this.tests.jUnit4Tests);
 		config.setjUnit5Tests(this.tests.jUnit5Tests);

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -36,6 +36,7 @@ public class FlacocoConfig {
 	private int testRunnerTimeoutInMs;
 	private String testRunnerJVMArgs;
 	private double threshold;
+	private boolean includeZero;
 
 	private List<String> jUnit4Tests;
 	private List<String> jUnit5Tests;
@@ -71,6 +72,7 @@ public class FlacocoConfig {
 		this.testRunnerTimeoutInMs = 1000000;
 		this.testRunnerJVMArgs = null;
 		this.threshold = 0.0;
+		this.includeZero = false;
 
 		this.jUnit4Tests = new ArrayList<>();
 		this.jUnit5Tests = new ArrayList<>();
@@ -259,6 +261,14 @@ public class FlacocoConfig {
 		this.threshold = threshold;
 	}
 
+	public boolean isIncludeZero() {
+		return includeZero;
+	}
+
+	public void setIncludeZero(boolean includeZero) {
+		this.includeZero = includeZero;
+	}
+
 	@Override
 	public String toString() {
 		return "FlacocoConfig{" +
@@ -277,6 +287,7 @@ public class FlacocoConfig {
 				", testRunnerTimeoutInMs=" + testRunnerTimeoutInMs +
 				", testRunnerJVMArgs='" + testRunnerJVMArgs + '\'' +
 				", threshold=" + threshold +
+				", includeZero=" + includeZero +
 				", jUnit4Tests='" + jUnit4Tests + '\'' +
 				", jUnit5Tests='" + jUnit5Tests + '\'' +
 				", family=" + family +

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -36,7 +36,7 @@ public class FlacocoConfig {
 	private int testRunnerTimeoutInMs;
 	private String testRunnerJVMArgs;
 	private double threshold;
-	private boolean includeZero;
+	private boolean includeZeros;
 
 	private List<String> jUnit4Tests;
 	private List<String> jUnit5Tests;
@@ -72,7 +72,7 @@ public class FlacocoConfig {
 		this.testRunnerTimeoutInMs = 1000000;
 		this.testRunnerJVMArgs = null;
 		this.threshold = 0.0;
-		this.includeZero = false;
+		this.includeZeros = false;
 
 		this.jUnit4Tests = new ArrayList<>();
 		this.jUnit5Tests = new ArrayList<>();
@@ -261,12 +261,12 @@ public class FlacocoConfig {
 		this.threshold = threshold;
 	}
 
-	public boolean isIncludeZero() {
-		return includeZero;
+	public boolean isIncludeZeros() {
+		return includeZeros;
 	}
 
-	public void setIncludeZero(boolean includeZero) {
-		this.includeZero = includeZero;
+	public void setIncludeZeros(boolean includeZeros) {
+		this.includeZeros = includeZeros;
 	}
 
 	@Override
@@ -287,7 +287,7 @@ public class FlacocoConfig {
 				", testRunnerTimeoutInMs=" + testRunnerTimeoutInMs +
 				", testRunnerJVMArgs='" + testRunnerJVMArgs + '\'' +
 				", threshold=" + threshold +
-				", includeZero=" + includeZero +
+				", includeZero=" + includeZeros +
 				", jUnit4Tests='" + jUnit4Tests + '\'' +
 				", jUnit5Tests='" + jUnit5Tests + '\'' +
 				", family=" + family +

--- a/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
@@ -64,7 +64,7 @@ public class SpectrumSuspiciousComputation {
 
 		// Filter according to threshold, sort by suspicious and return
 		return result.entrySet().stream()
-				.filter(x -> x.getValue().getScore() > config.getThreshold())
+				.filter(x -> x.getValue().getScore() >= config.getThreshold() && (x.getValue().getScore() > 0.0 || config.isIncludeZero()))
 				.sorted(Map.Entry.<String, Suspiciousness>comparingByValue().reversed())
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
 

--- a/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
@@ -64,7 +64,7 @@ public class SpectrumSuspiciousComputation {
 
 		// Filter according to threshold, sort by suspicious and return
 		return result.entrySet().stream()
-				.filter(x -> x.getValue().getScore() >= config.getThreshold() && (x.getValue().getScore() > 0.0 || config.isIncludeZero()))
+				.filter(x -> x.getValue().getScore() >= config.getThreshold() && (x.getValue().getScore() > 0.0 || config.isIncludeZeros()))
 				.sorted(Map.Entry.<String, Suspiciousness>comparingByValue().reversed())
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -74,7 +74,7 @@ public class FlacocoTest {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
-		config.setThreshold(0.5);
+		config.setThreshold(0.51);
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
@@ -88,7 +88,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		// no lines below or equal to 0.5 in suspiciousness are returned
+		// no lines below to 0.51 in suspiciousness are returned
 		assertEquals(3, susp.size());
 
 		// Line executed only by the failing
@@ -97,6 +97,46 @@ public class FlacocoTest {
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
 		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+	}
+
+	@Test
+	public void testExampleFL1SpectrumBasedOchiaiDefaultModeIncludeZero() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
+		config.setThreshold(0.0);
+		config.setIncludeZero(true);
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<String, Suspiciousness> susp = flacoco.runDefault();
+
+		for (String line : susp.keySet()) {
+			System.out.println("" + line + " " + susp.get(line));
+		}
+
+		// all lines are returned
+		assertEquals(8, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+
+		// Lines with no failing test executing them have a 0.0 score
+		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@11").getScore(), 0);
+		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@13").getScore(), 0);
+		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0);
+		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0);
 	}
 
 	@Test

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -105,7 +105,7 @@ public class FlacocoTest {
 		FlacocoConfig config = FlacocoConfig.getInstance();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setThreshold(0.0);
-		config.setIncludeZero(true);
+		config.setIncludeZeros(true);
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -107,7 +107,7 @@ public class FlacocoMainTest {
 				"--testRunnerTimeoutInMs", "10000",
 				"--testRunnerJVMArgs", "-Xms16M",
 				"-v",
-				"--includeZero"
+				"--includeZeros"
 		});
 	}
 

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -106,7 +106,8 @@ public class FlacocoMainTest {
 				"--testRunnerVerbose",
 				"--testRunnerTimeoutInMs", "10000",
 				"--testRunnerJVMArgs", "-Xms16M",
-				"-v"
+				"-v",
+				"--includeZero"
 		});
 	}
 


### PR DESCRIPTION
The behavior was that all lines with a score `>` than the threshold would be returned.

This is not the behavior `astor` expects, and as such this PR makes it to be `>=`.

The new option, `includeZero`, makes it so that zero valued scores are only returned if it is set. I think this is better than setting the threshold to a default value of `0.000...1`.