### PR TITLE
Partly fix constructor coverage and junit classpath issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,13 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.7</version>
+			<version>2.11.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
+			<version>4.13.2</version>
 		</dependency>
 
 		<dependency>
@@ -59,21 +59,39 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-commons</artifactId>
+			<version>1.7.2</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.3.2</version>
+			<version>5.7.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.3.2</version>
+			<version>5.7.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>5.7.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-engine</artifactId>
+			<version>1.7.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.3.2</version>
+			<version>1.7.2</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,23 +39,11 @@
 	</repositories>
 
 	<dependencies>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>2.11.0</version>
-		</dependency>
-
+		<!-- dependencies for the junit classpah -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-core</artifactId>
-			<version>3.11.2</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -94,28 +82,11 @@
 			<version>1.7.2</version>
 		</dependency>
 
+		<!-- regular dependencies -->
 		<dependency>
 			<groupId>eu.stamp-project</groupId>
 			<artifactId>test-runner</artifactId>
 			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
-
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.17</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-jcl</artifactId>
-			<version>2.14.1</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-core</artifactId>
-			<version>3.8.1</version>
 		</dependency>
 
 		<dependency>
@@ -131,17 +102,21 @@
 		</dependency>
 
 		<dependency>
+			<groupId>log4j</groupId>
+			<artifactId>log4j</artifactId>
+			<version>1.2.17</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-jcl</artifactId>
+			<version>2.14.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>info.picocli</groupId>
 			<artifactId>picocli</artifactId>
 			<version>4.6.1</version>
-		</dependency>
-
-		<!-- for testing System.exit -->
-		<dependency>
-			<groupId>com.github.stefanbirkner</groupId>
-			<artifactId>system-rules</artifactId>
-			<version>1.19.0</version>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>
@@ -154,6 +129,22 @@
 			<groupId>net.sf.supercsv</groupId>
 			<artifactId>super-csv</artifactId>
 			<version>2.4.0</version>
+		</dependency>
+
+		<!-- for testing System.exit -->
+		<dependency>
+			<groupId>com.github.stefanbirkner</groupId>
+			<artifactId>system-rules</artifactId>
+			<version>1.19.0</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- for mocks -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.11.2</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,36 +50,42 @@
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-commons</artifactId>
 			<version>1.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
 			<version>5.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
 			<version>5.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-engine</artifactId>
 			<version>1.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
 			<version>1.7.2</version>
+			<scope>compile</scope>
 		</dependency>
 
 		<!-- regular dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -95,12 +95,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-			<version>5.3.2</version>
-		</dependency>
-
-		<dependency>
 			<groupId>eu.stamp-project</groupId>
 			<artifactId>test-runner</artifactId>
 			<version>3.0.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,45 +47,27 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-commons</artifactId>
-			<version>1.7.2</version>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.7.2</version>
-			<scope>compile</scope>
+			<version>5.3.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>5.7.2</version>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-params</artifactId>
-			<version>5.7.2</version>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.platform</groupId>
-			<artifactId>junit-platform-engine</artifactId>
-			<version>1.7.2</version>
-			<scope>compile</scope>
+			<version>5.3.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.7.2</version>
-			<scope>compile</scope>
+			<version>1.3.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>5.3.2</version>
 		</dependency>
 
 		<!-- regular dependencies -->

--- a/src/main/java/fr/spoonlabs/flacoco/cli/export/JSONExporter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/export/JSONExporter.java
@@ -1,7 +1,7 @@
 package fr.spoonlabs.flacoco.cli.export;
 
-import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import fr.spoonlabs.flacoco.api.Suspiciousness;
 
 import java.io.IOException;

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
@@ -46,15 +46,15 @@ public abstract class TestFrameworkStrategy {
 		String jacocoClassPath;
 
 		junitClasspath = mavenHome + "junit/junit/4.13.2/junit-4.13.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.7.2/junit-jupiter-api-5.7.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.7.2/junit-jupiter-engine-5.7.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.7.2/junit-jupiter-params-5.7.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-engine/1.7.2/junit-platform-engine-1.7.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.7.2/junit-platform-launcher-1.7.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar";
+				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-commons/1.3.2/junit-platform-commons-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-engine/1.3.2/junit-platform-engine-1.3.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
 
 		jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.7/org.jacoco.core-0.8.7.jar";
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
@@ -45,16 +45,16 @@ public abstract class TestFrameworkStrategy {
 		String junitClasspath;
 		String jacocoClassPath;
 
-		junitClasspath = mavenHome + "junit/junit/4.12/junit-4.12.jar" + File.pathSeparatorChar
+		junitClasspath = mavenHome + "junit/junit/4.13.2/junit-4.13.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-commons/1.7.2/junit-platform-commons-1.7.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.7.2/junit-jupiter-api-5.7.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.7.2/junit-jupiter-engine-5.7.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.7.2/junit-jupiter-params-5.7.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-engine/1.7.2/junit-platform-engine-1.7.2.jar" + File.pathSeparatorChar
+				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.7.2/junit-platform-launcher-1.7.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-commons/1.3.2/junit-platform-commons-1.3.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-engine/5.3.2/junit-jupiter-engine-5.3.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/jupiter/junit-jupiter-params/5.3.2/junit-jupiter-params-5.3.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-engine/1.3.2/junit-platform-engine-1.3.2.jar" + File.pathSeparatorChar
-				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
+				+ mavenHome + "org/opentest4j/opentest4j/1.1.1/opentest4j-1.1.1.jar";
 
 		jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.7/org.jacoco.core-0.8.7.jar";
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -57,7 +57,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -68,6 +68,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -121,7 +123,7 @@ public class FlacocoTest {
 		}
 
 		// all lines are returned
-		assertEquals(8, susp.size());
+		assertEquals(10, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -132,6 +134,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 
 		// Lines with no failing test executing them have a 0.0 score
 		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@11").getScore(), 0);
@@ -165,7 +169,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -173,6 +177,8 @@ public class FlacocoTest {
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
 		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
@@ -200,7 +206,7 @@ public class FlacocoTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.keySet().size());
+		assertEquals(8, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
@@ -213,6 +219,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	@Test
@@ -233,7 +241,7 @@ public class FlacocoTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(5, susp.keySet().size());
+		assertEquals(7, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
@@ -245,6 +253,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	@Test
@@ -267,7 +277,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -280,6 +290,8 @@ public class FlacocoTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -296,7 +308,8 @@ public class FlacocoTest {
 		// Run default mode
 		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
 
-		assertEquals(4, susp.size());
+		// The two lines of the (empty) constructor get mapped to the same CtStatement
+		assertEquals(5, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
@@ -317,6 +330,7 @@ public class FlacocoTest {
 					break;
 				// Lines executed by all test
 				case 10:
+				case 5:
 					assertEquals(0.5, susp.get(ctStatement).getScore(), 0);
 					break;
 			}
@@ -741,7 +755,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -752,6 +766,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -777,7 +793,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -788,6 +804,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -814,7 +832,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -827,6 +845,8 @@ public class FlacocoTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -847,7 +867,8 @@ public class FlacocoTest {
 		// Run default mode
 		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
 
-		assertEquals(4, susp.size());
+		// The two lines of the (empty) constructor get mapped to the same CtStatement
+		assertEquals(5, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
@@ -868,6 +889,7 @@ public class FlacocoTest {
 					break;
 				// Lines executed by all test
 				case 10:
+				case 5:
 					assertEquals(0.5, susp.get(ctStatement).getScore(), 0);
 					break;
 			}
@@ -896,7 +918,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -907,6 +929,8 @@ public class FlacocoTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -927,7 +951,8 @@ public class FlacocoTest {
 		// Run default mode
 		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
 
-		assertEquals(4, susp.size());
+		// The two lines of the (empty) constructor get mapped to the same CtStatement
+		assertEquals(5, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
 			System.out.println("" + ctStatement + " " + susp.get(ctStatement));
@@ -948,6 +973,7 @@ public class FlacocoTest {
 					break;
 				// Lines executed by all test
 				case 10:
+				case 5:
 					assertEquals(0.5, susp.get(ctStatement).getScore(), 0);
 					break;
 			}
@@ -972,7 +998,7 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.size());
 
 		// Line executed by all failing test cases
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
@@ -987,6 +1013,8 @@ public class FlacocoTest {
 
 		// Line executed by all tests (2 passing, 2 failing)
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	/**

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -58,8 +58,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -159,8 +159,8 @@ public class CoverageRunnerTest {
 		assertEquals(1, matrix.getFailingTestCases().size());
 		assertEquals(5, matrix.getTests().size());
 
-		// 10 executed lines
-		assertEquals(10, matrix.getResultExecution().keySet().size());
+		// 12 executed lines
+		assertEquals(12, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
@@ -196,8 +196,8 @@ public class CoverageRunnerTest {
 		assertEquals(1, matrix.getFailingTestCases().size());
 		assertEquals(5, matrix.getTests().size());
 
-		// 9 executed lines
-		assertEquals(9, matrix.getResultExecution().keySet().size());
+		// 11 executed lines
+		assertEquals(11, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
@@ -466,8 +466,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -583,8 +583,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -680,8 +680,8 @@ public class CoverageRunnerTest {
 		assertEquals(8, matrix.getTests().size());
 		assertEquals(2, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -782,8 +782,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -883,8 +883,8 @@ public class CoverageRunnerTest {
 		assertEquals(8, matrix.getTests().size());
 		assertEquals(2, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -980,8 +980,8 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(2, matrix.getFailingTestCases().size());
 
-		// 8 executed lines
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		// 10 executed lines
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -48,7 +48,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -59,6 +59,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -76,11 +78,11 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@22").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@22").getScore(), 0); // exception thrown here
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@18").getScore(), 0.01);
@@ -89,6 +91,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	@Test
@@ -106,7 +110,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(5, susp.size());
+		assertEquals(7, susp.keySet().size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
@@ -118,6 +122,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	@Test
@@ -137,7 +143,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -150,6 +156,8 @@ public class SpectrumRunnerTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -347,7 +355,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -358,6 +366,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -379,7 +389,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -390,6 +400,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -411,7 +423,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(4, susp.size());
+		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
@@ -422,6 +434,8 @@ public class SpectrumRunnerTest {
 
 		// Lines executed by all test
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
 	@Test
@@ -439,7 +453,7 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(8, susp.size());
 
 		// Line executed by all failing test cases
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
@@ -454,6 +468,8 @@ public class SpectrumRunnerTest {
 
 		// Line executed by all tests (2 passing, 2 failing)
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
 	}
 
 	@Test

--- a/src/test/resources/expected.csv
+++ b/src/test/resources/expected.csv
@@ -1,4 +1,6 @@
 fr/spoonlabs/FLtest1/Calculator@-@15,1.0
 fr/spoonlabs/FLtest1/Calculator@-@14,0.7071067811865475
 fr/spoonlabs/FLtest1/Calculator@-@12,0.5773502691896258
+fr/spoonlabs/FLtest1/Calculator@-@5,0.5
+fr/spoonlabs/FLtest1/Calculator@-@6,0.5
 fr/spoonlabs/FLtest1/Calculator@-@10,0.5

--- a/src/test/resources/expected.custom
+++ b/src/test/resources/expected.custom
@@ -1,1 +1,1 @@
-fr/spoonlabs/FLtest1/Calculator@-@15,1.0fr/spoonlabs/FLtest1/Calculator@-@14,0.7071067811865475fr/spoonlabs/FLtest1/Calculator@-@12,0.5773502691896258fr/spoonlabs/FLtest1/Calculator@-@10,0.5
+fr/spoonlabs/FLtest1/Calculator@-@15,1.0fr/spoonlabs/FLtest1/Calculator@-@14,0.7071067811865475fr/spoonlabs/FLtest1/Calculator@-@12,0.5773502691896258fr/spoonlabs/FLtest1/Calculator@-@5,0.5fr/spoonlabs/FLtest1/Calculator@-@6,0.5fr/spoonlabs/FLtest1/Calculator@-@10,0.5

--- a/src/test/resources/expected.json
+++ b/src/test/resources/expected.json
@@ -1,1 +1,1 @@
-{"fr/spoonlabs/FLtest1/Calculator@-@15":1.0,"fr/spoonlabs/FLtest1/Calculator@-@14":0.7071067811865475,"fr/spoonlabs/FLtest1/Calculator@-@12":0.5773502691896258,"fr/spoonlabs/FLtest1/Calculator@-@10":0.5}
+{"fr/spoonlabs/FLtest1/Calculator@-@15":1.0,"fr/spoonlabs/FLtest1/Calculator@-@14":0.7071067811865475,"fr/spoonlabs/FLtest1/Calculator@-@12":0.5773502691896258,"fr/spoonlabs/FLtest1/Calculator@-@5":0.5,"fr/spoonlabs/FLtest1/Calculator@-@6":0.5,"fr/spoonlabs/FLtest1/Calculator@-@10":0.5}


### PR DESCRIPTION
Bumping the version of the junit dependencies, and making the classpath construction coherent partly fixes issue #42 (only for JUnit4 tests).