### PR TITLE
Online mode

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
@@ -19,7 +19,10 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 @Command(name = "FlacocoMain", mixinStandardHelpOptions = true, version = "0.0.1", description = "Flacoco: fault localization")
@@ -113,6 +116,12 @@ public class FlacocoMain implements Callable<Integer> {
 	@Option(names = {"--ignoredTests"}, description = "Tests to be ignored during test execution. Both qualified class and qualified method names are supported.")
 	Set<String> ignoredTests = new HashSet<>();
 
+	@Option(names = {"--jacocoIncludes"}, description = "Class patterns to be recorded in by jacoco")
+	Set<String> jacocoIncludes = new HashSet<>();
+
+	@Option(names = {"--jacocoExcludes"}, description = "Class patterns to be excluded by jacoco")
+	Set<String> jacocoExcludes = new HashSet<>();
+
 	@CommandLine.ArgGroup(exclusive = false, multiplicity = "0..1", heading = "Setting any of these options will result in test detection being bypassed.")
 	Tests tests = new Tests();
 
@@ -190,6 +199,8 @@ public class FlacocoMain implements Callable<Integer> {
 		config.setIgnoredTests(this.ignoredTests);
 		config.setjUnit4Tests(this.tests.jUnit4Tests);
 		config.setjUnit5Tests(this.tests.jUnit5Tests);
+		config.setJacocoIncludes(this.jacocoIncludes);
+		config.setJacocoExcludes(this.jacocoExcludes);
 
 		config.setSpectrumFormula(this.spectrumFormula);
 	}

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -46,6 +46,8 @@ public class FlacocoConfig {
 	private Set<String> ignoredTests;
 	private Set<String> jUnit4Tests;
 	private Set<String> jUnit5Tests;
+	private Set<String> jacocoIncludes;
+	private Set<String> jacocoExcludes;
 
 	private FaultLocalizationFamily family;
 	//------Options for spectrum-based fault localization------
@@ -85,6 +87,8 @@ public class FlacocoConfig {
 		this.ignoredTests = new HashSet<>();
 		this.jUnit4Tests = new HashSet<>();
 		this.jUnit5Tests = new HashSet<>();
+		this.jacocoIncludes = new HashSet<>();
+		this.jacocoExcludes = new HashSet<>();
 
 		this.family = FaultLocalizationFamily.SPECTRUM_BASED;
 		this.spectrumFormula = SpectrumFormula.OCHIAI;
@@ -262,6 +266,22 @@ public class FlacocoConfig {
 		this.jUnit5Tests = jUnit5Tests;
 	}
 
+	public Set<String> getJacocoIncludes() {
+		return jacocoIncludes;
+	}
+
+	public void setJacocoIncludes(Set<String> jacocoIncludes) {
+		this.jacocoIncludes = jacocoIncludes;
+	}
+
+	public Set<String> getJacocoExcludes() {
+		return jacocoExcludes;
+	}
+
+	public void setJacocoExcludes(Set<String> jacocoExcludes) {
+		this.jacocoExcludes = jacocoExcludes;
+	}
+
 	public FaultLocalizationFamily getFamily() {
 		return family;
 	}
@@ -326,6 +346,8 @@ public class FlacocoConfig {
 				", ignoredTests=" + ignoredTests +
 				", jUnit4Tests=" + jUnit4Tests +
 				", jUnit5Tests=" + jUnit5Tests +
+				", jacocoIncludes=" + jacocoIncludes +
+				", jacocoExcludes=" + jacocoExcludes +
 				", family=" + family +
 				", spectrumFormula=" + spectrumFormula +
 				'}';

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageFromSingleTestUnit.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageFromSingleTestUnit.java
@@ -34,11 +34,7 @@ public class CoverageFromSingleTestUnit {
 		this.testMethod = testMethod;
 		this.coveredTestResultPerTestMethod = result;
 
-		this.isPassing = result.getPassingTests().contains(testMethod.getFullyQualifiedMethodName())
-				&& result.getFailingTests().stream().map(x -> x.testClassName + "#" + x.testCaseName)
-				.noneMatch(x -> x.equals(testMethod.getFullyQualifiedMethodName()))
-				&& result.getAssumptionFailingTests().stream().map(x -> x.testClassName + "#" + x.testCaseName)
-				.noneMatch(x -> x.equals(testMethod.getFullyQualifiedMethodName()));
+		this.isPassing = result.getPassingTests().contains(testMethod.getFullyQualifiedMethodName());
 
 		this.isSkip = result.getIgnoredTests().contains(testMethod.getFullyQualifiedMethodName());
 	}

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
@@ -40,7 +40,7 @@ public class CoverageMatrix {
 	 * @return The key for iLineNumber in iClassNameCovered
 	 */
 	public static String getLineKey(String iClassNameCovered, int iLineNumber) {
-		return String.format("%s%s%d", iClassNameCovered, JOIN, iLineNumber);
+		return iClassNameCovered + JOIN + iLineNumber;
 	}
 
 	/**

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/JUnit4Strategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/JUnit4Strategy.java
@@ -31,7 +31,7 @@ public class JUnit4Strategy extends TestFrameworkStrategy {
 		logger.debug("Running " + testContext);
 		this.setupTestRunnerEntryPoint();
 
-		return EntryPoint.runCoveredTestResultPerTestMethods(
+		return EntryPoint.runOnlineCoveredTestResultPerTestMethods(
 				this.computeClasspath(),
 				FlacocoConfig.getInstance().getBinJavaDir(),
 				FlacocoConfig.getInstance().getBinTestDir(),

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/JUnit5Strategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/JUnit5Strategy.java
@@ -34,7 +34,7 @@ public class JUnit5Strategy extends TestFrameworkStrategy {
 		// test-runner needs a flag for JUnit5 tests
 		EntryPoint.jUnit5Mode = true;
 
-		return EntryPoint.runCoveredTestResultPerTestMethods(
+		return EntryPoint.runOnlineCoveredTestResultPerTestMethods(
 				this.computeClasspath(),
 				FlacocoConfig.getInstance().getBinJavaDir(),
 				FlacocoConfig.getInstance().getBinTestDir(),

--- a/src/main/java/fr/spoonlabs/flacoco/core/test/method/StringTestMethod.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/test/method/StringTestMethod.java
@@ -11,11 +11,11 @@ public class StringTestMethod implements TestMethod {
 
     private String fullyQualifiedClassName;
 
-    private String simpleMethodName;
+    private String fullyQualifiedMethodName;
 
     public StringTestMethod(String fullyQualifiedClassName, String simpleMethodName) {
         this.fullyQualifiedClassName = fullyQualifiedClassName;
-        this.simpleMethodName = simpleMethodName;
+        this.fullyQualifiedMethodName = fullyQualifiedClassName + "#" + simpleMethodName;
     }
 
     public String getFullyQualifiedClassName() {
@@ -23,7 +23,7 @@ public class StringTestMethod implements TestMethod {
     }
 
     public String getFullyQualifiedMethodName() {
-        return fullyQualifiedClassName + "#" + simpleMethodName;
+        return fullyQualifiedMethodName;
     }
 
     @Override

--- a/src/main/java/fr/spoonlabs/flacoco/core/test/strategies/classloader/ClassloaderStrategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/test/strategies/classloader/ClassloaderStrategy.java
@@ -52,13 +52,11 @@ public class ClassloaderStrategy implements TestDetectionStrategy {
         for (String dir : config.getBinTestDir()) {
             urls.add(new File(dir).toURI().toURL());
         }
-        System.out.println(config);
         if (!config.getClasspath().isEmpty()) {
             for (String dir : config.getClasspath().split(File.pathSeparator)) {
                 urls.add(new File(dir).toURI().toURL());
             }
         }
-        System.out.println(urls);
         return urls.toArray(new URL[0]);
     }
 }

--- a/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
@@ -6,7 +6,6 @@ import org.apache.log4j.Logger;
 import spoon.Launcher;
 import spoon.reflect.code.CtStatement;
 
-import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/test/java/ch/scheitlin/alex/java/StackTraceParserTest.java
+++ b/src/test/java/ch/scheitlin/alex/java/StackTraceParserTest.java
@@ -23,14 +23,14 @@
  */
 package ch.scheitlin.alex.java;
 
-import static org.junit.Assert.fail;
-
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.FileNotFoundException;
 import java.util.Arrays;
 import java.util.List;
+
+import static org.junit.Assert.fail;
 
 public class StackTraceParserTest {
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -9,7 +9,9 @@ import org.junit.rules.TemporaryFolder;
 import spoon.reflect.code.CtStatement;
 
 import java.io.File;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
@@ -11,11 +11,8 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static fr.spoonlabs.flacoco.TestUtils.getJavaVersion;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
@@ -30,6 +30,8 @@ public class Math70Test {
     public void setUp() {
         // Run only on Java8
         Assume.assumeTrue(getJavaVersion() == 8);
+        // FIXME: In CI, `testMath70` fails due to the test-runner args being too big (#57)
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
 
         LogManager.getRootLogger().setLevel(Level.INFO);
         FlacocoConfig config = FlacocoConfig.getInstance();

--- a/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
@@ -11,8 +11,11 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static fr.spoonlabs.flacoco.TestUtils.getJavaVersion;
 import static org.junit.Assert.assertEquals;
@@ -31,10 +34,9 @@ public class Math70Test {
         // Run only on Java8
         Assume.assumeTrue(getJavaVersion() == 8);
 
-        LogManager.getRootLogger().setLevel(Level.DEBUG);
+        LogManager.getRootLogger().setLevel(Level.INFO);
         FlacocoConfig config = FlacocoConfig.getInstance();
         config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
-        config.setTestRunnerVerbose(true);
     }
 
     @After

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -75,6 +75,8 @@ public class FlacocoMainTest {
 								 "fr.spoonlabs.FLtest1.CalculatorTest#testMul" + " " +
 							     "fr.spoonlabs.FLtest1.CalculatorTest#testDiv",
 				"--threshold", "0.0",
+				"--jacocoIncludes", "fr.spoonlabs.FLtest1.*",
+				"--jacocoExcludes", "org.junit.*",
 				"--complianceLevel", "8"
 		});
 	}


### PR DESCRIPTION
- Use the new online mode of `test-runner` and new options related to its usage.
- Use the optimized compressed coverage, which only analyzes executed classes.
- Compute `jacocoIncludes` automatically.
- Optimize some minor operations.

Ready after https://github.com/STAMP-project/test-runner/pull/117 is merged

Closes https://github.com/SpoonLabs/flacoco/issues/85
Related to https://github.com/SpoonLabs/flacoco/issues/74