### PR TITLE
Fix JUnit5 test method modifiers

### DIFF
--- a/examples/exampleFL4JUnit5/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
+++ b/examples/exampleFL4JUnit5/FLtest1/src/test/java/fr/spoonlabs/FLtest1/CalculatorTest.java
@@ -16,7 +16,7 @@ public class CalculatorTest {
 	}
 
 	@Test
-	public void testSubs() {
+	void testSubs() {
 
 		Assertions.assertEquals(2, c.calculate("-", 3, 1));
 

--- a/src/main/java/fr/spoonlabs/flacoco/core/test/strategies/classloader/finder/filters/TestMethodFilter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/test/strategies/classloader/finder/filters/TestMethodFilter.java
@@ -90,8 +90,13 @@ public class TestMethodFilter {
         List<TestMethod> testMethods = new ArrayList<>();
 
         try {
-            for (Method method : clazz.getMethods()) {
-                if (method.getAnnotation(org.junit.jupiter.api.Test.class) != null && !isIgnoredMethod(clazz, method)) {
+            // JUnit 5 allows public, protected or package-private methods, so we get all declared methods and filter out
+            // the private ones
+            for (Method method : clazz.getDeclaredMethods()) {
+                if (method.getAnnotation(org.junit.jupiter.api.Test.class) != null
+                        && !isPrivateMethod(method)
+                        && !isIgnoredMethod(clazz, method)
+                ) {
                     testMethods.add(new StringTestMethod(clazz.getCanonicalName(), method.getName()));
                 }
             }
@@ -120,6 +125,10 @@ public class TestMethodFilter {
 
     private boolean isPublicMethod(Method method) {
         return (method.getModifiers() & Modifier.PUBLIC) != 0;
+    }
+
+    private boolean isPrivateMethod(Method method) {
+        return (method.getModifiers() & Modifier.PRIVATE) != 0;
     }
 
     private boolean isStaticMethod(Method method) {


### PR DESCRIPTION
JUnit5 supports `public`, `protected` and `package-private` test methods, so we need to search for all of them.

This was the bug causing https://github.com/SpoonLabs/flacoco/issues/87#issuecomment-903735838. Thanks for pointing it out @danglotb!