### PR TITLE
Simplify Flacoco results

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/api/Flacoco.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/Flacoco.java
@@ -1,13 +1,10 @@
 package fr.spoonlabs.flacoco.api;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.FaultLocalizationRunner;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumRunner;
-import fr.spoonlabs.flacoco.utils.spoon.SpoonConverter;
 import org.apache.log4j.Logger;
-import spoon.reflect.code.CtStatement;
-
-import java.util.Map;
 
 /**
  * This class serves as the main entry point to Flacoco.
@@ -23,23 +20,13 @@ public class Flacoco implements FlacocoAPI {
 	}
 
 	/**
-	 * Default run method for Flacoco.
-	 * @return Mapping between source code lines and suspiciousness scores
+	 * Run method for Flacoco.
+	 * @return FlacocoResult populated with the fault localization data.
 	 */
 	@Override
-	public Map<String, Suspiciousness> runDefault() {
+	public FlacocoResult run() {
 		this.logger.info("Running Flacoco...");
 		return getRunner().run();
-	}
-
-	/**
-	 * Spoon mode for Flacoco
-	 * @return Mapping between CtStatements representing a code lines and suspiciousness scores
-	 */
-	@Override
-	public Map<CtStatement, Suspiciousness> runSpoon() {
-		Map<String, Suspiciousness> defaultResults = runDefault();
-		return SpoonConverter.convert(defaultResults);
 	}
 
 	/**

--- a/src/main/java/fr/spoonlabs/flacoco/api/FlacocoAPI.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/FlacocoAPI.java
@@ -1,13 +1,13 @@
 package fr.spoonlabs.flacoco.api;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import spoon.reflect.code.CtStatement;
 
 import java.util.Map;
 
 public interface FlacocoAPI {
 
-	Map<String, Suspiciousness> runDefault();
-
-	Map<CtStatement, Suspiciousness> runSpoon();
+	FlacocoResult run();
 
 }

--- a/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
@@ -1,0 +1,40 @@
+package fr.spoonlabs.flacoco.api.result;
+
+import fr.spoonlabs.flacoco.core.test.method.TestMethod;
+import spoon.reflect.code.CtStatement;
+
+import java.util.Map;
+import java.util.Set;
+
+public class FlacocoResult {
+
+    private Map<Location, Suspiciousness> defaultSuspiciousnessMap;
+
+    private Map<CtStatement, Suspiciousness> spoonSuspiciousnessMap;
+
+    private Set<TestMethod> failingTests;
+
+    public Map<Location, Suspiciousness> getDefaultSuspiciousnessMap() {
+        return defaultSuspiciousnessMap;
+    }
+
+    public void setDefaultSuspiciousnessMap(Map<Location, Suspiciousness> defaultSuspiciousnessMap) {
+        this.defaultSuspiciousnessMap = defaultSuspiciousnessMap;
+    }
+
+    public Map<CtStatement, Suspiciousness> getSpoonSuspiciousnessMap() {
+        return spoonSuspiciousnessMap;
+    }
+
+    public void setSpoonSuspiciousnessMap(Map<CtStatement, Suspiciousness> spoonSuspiciousnessMap) {
+        this.spoonSuspiciousnessMap = spoonSuspiciousnessMap;
+    }
+
+    public Set<TestMethod> getFailingTests() {
+        return failingTests;
+    }
+
+    public void setFailingTests(Set<TestMethod> failingTests) {
+        this.failingTests = failingTests;
+    }
+}

--- a/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
@@ -12,6 +12,8 @@ public class FlacocoResult {
 
     private Map<CtStatement, Suspiciousness> spoonSuspiciousnessMap;
 
+    private Map<Location, CtStatement> locationStatementMap;
+
     private Set<TestMethod> failingTests;
 
     public Map<Location, Suspiciousness> getDefaultSuspiciousnessMap() {
@@ -28,6 +30,14 @@ public class FlacocoResult {
 
     public void setSpoonSuspiciousnessMap(Map<CtStatement, Suspiciousness> spoonSuspiciousnessMap) {
         this.spoonSuspiciousnessMap = spoonSuspiciousnessMap;
+    }
+
+    public Map<Location, CtStatement> getLocationStatementMap() {
+        return locationStatementMap;
+    }
+
+    public void setLocationStatementMap(Map<Location, CtStatement> locationStatementMap) {
+        this.locationStatementMap = locationStatementMap;
     }
 
     public Set<TestMethod> getFailingTests() {

--- a/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/result/FlacocoResult.java
@@ -6,6 +6,17 @@ import spoon.reflect.code.CtStatement;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * The result of flacoco.
+ * <p>
+ * Contains a mapping between suspicious {@link Location} and their {@link Suspiciousness} values.
+ * <p>
+ * If {@link fr.spoonlabs.flacoco.core.config.FlacocoConfig} has the parameter `computeSpoonResults` enabled,
+ * a mapping betweek {@link CtStatement} and {@link Suspiciousness}, as well as the mapping between
+ * {@link Location} and {@link CtStatement} can be found under `getSpoonSuspiciousnessMap()` and `getLocationStatementMap()` respectively.
+ * <p>
+ * Otherwise, both these getter <b>will return null</b>.
+ */
 public class FlacocoResult {
 
     private Map<Location, Suspiciousness> defaultSuspiciousnessMap;

--- a/src/main/java/fr/spoonlabs/flacoco/api/result/Location.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/result/Location.java
@@ -1,0 +1,41 @@
+package fr.spoonlabs.flacoco.api.result;
+
+import java.util.Objects;
+
+public class Location {
+
+    private String className;
+
+    private Integer lineNumber;
+
+    public Location(String className, Integer lineNumber) {
+        this.className = className;
+        this.lineNumber = lineNumber;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public Integer getLineNumber() {
+        return lineNumber;
+    }
+
+    @Override
+    public String toString() {
+        return this.className + "@-@" + this.lineNumber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Location location = (Location) o;
+        return Objects.equals(className, location.className) && Objects.equals(lineNumber, location.lineNumber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, lineNumber);
+    }
+}

--- a/src/main/java/fr/spoonlabs/flacoco/api/result/Suspiciousness.java
+++ b/src/main/java/fr/spoonlabs/flacoco/api/result/Suspiciousness.java
@@ -1,4 +1,4 @@
-package fr.spoonlabs.flacoco.api;
+package fr.spoonlabs.flacoco.api.result;
 
 import fr.spoonlabs.flacoco.core.test.method.TestMethod;
 

--- a/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/FlacocoMain.java
@@ -1,7 +1,7 @@
 package fr.spoonlabs.flacoco.cli;
 
 import fr.spoonlabs.flacoco.api.Flacoco;
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.cli.export.CSVExporter;
 import fr.spoonlabs.flacoco.cli.export.FlacocoExporter;
 import fr.spoonlabs.flacoco.cli.export.JSONExporter;
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -155,9 +154,9 @@ public class FlacocoMain implements Callable<Integer> {
 		setupFlacocoConfig();
 
 		Flacoco flacoco = new Flacoco();
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		exportResults(susp);
+		exportResults(result);
 
 		return 0;
 	}
@@ -205,11 +204,11 @@ public class FlacocoMain implements Callable<Integer> {
 		config.setSpectrumFormula(this.spectrumFormula);
 	}
 
-	private void exportResults(Map<String, Suspiciousness> results) {
+	private void exportResults(FlacocoResult result) {
 		try {
 			FlacocoExporter exporter = getExporter();
 			OutputStreamWriter outputStreamWriter = getOutputStreamWriter(exporter);
-			exporter.export(results, outputStreamWriter);
+			exporter.export(result, outputStreamWriter);
 			outputStreamWriter.close();
 		} catch (IOException e) {
 			throw new RuntimeException(e);

--- a/src/main/java/fr/spoonlabs/flacoco/cli/export/CSVExporter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/export/CSVExporter.java
@@ -1,6 +1,8 @@
 package fr.spoonlabs.flacoco.cli.export;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import org.supercsv.io.CsvListWriter;
 import org.supercsv.prefs.CsvPreference;
 
@@ -13,10 +15,10 @@ public class CSVExporter implements FlacocoExporter {
 	private static final CsvPreference csvPreference = new CsvPreference.Builder(CsvPreference.STANDARD_PREFERENCE).build();
 
 	@Override
-	public void export(Map<String, Suspiciousness> results, OutputStreamWriter outputStream) throws IOException {
+	public void export(FlacocoResult result, OutputStreamWriter outputStream) throws IOException {
 		// TODO: Using a CsvListWriter because CsvMapWriter had some issues. Ideally, we could use CsvMapWriter and reduce the complexity here
 		CsvListWriter writer = new CsvListWriter(outputStream, csvPreference);
-		for (Map.Entry<String, Suspiciousness> entry : results.entrySet()) {
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
 			writer.write(entry.getKey(), entry.getValue().getScore());
 		}
 		writer.close();

--- a/src/main/java/fr/spoonlabs/flacoco/cli/export/FlacocoExporter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/export/FlacocoExporter.java
@@ -1,14 +1,13 @@
 package fr.spoonlabs.flacoco.cli.export;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.util.Map;
 
 public interface FlacocoExporter {
 
-	void export(Map<String, Suspiciousness> results, OutputStreamWriter outputStream) throws IOException;
+	void export(FlacocoResult result, OutputStreamWriter outputStream) throws IOException;
 
 	String extension();
 

--- a/src/main/java/fr/spoonlabs/flacoco/cli/export/JSONExporter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/cli/export/JSONExporter.java
@@ -2,7 +2,7 @@ package fr.spoonlabs.flacoco.cli.export;
 
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 
 import java.io.IOException;
 import java.io.OutputStreamWriter;
@@ -15,12 +15,12 @@ import java.util.stream.Collectors;
 public class JSONExporter implements FlacocoExporter {
 
 	@Override
-	public void export(Map<String, Suspiciousness> results, OutputStreamWriter outputStream) throws IOException {
+	public void export(FlacocoResult result, OutputStreamWriter outputStream) throws IOException {
 		Gson gson = new Gson();
 		Type gsonType = new TypeToken<HashMap>() {}.getType();
 
 		String gsonString = gson.toJson(
-				results.entrySet().stream()
+				result.getDefaultSuspiciousnessMap().entrySet().stream()
 						.collect(Collectors.toMap(
 								Map.Entry::getKey,
 								e -> e.getValue().getScore(),

--- a/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/config/FlacocoConfig.java
@@ -49,6 +49,8 @@ public class FlacocoConfig {
 	private Set<String> jacocoIncludes;
 	private Set<String> jacocoExcludes;
 
+	private boolean computeSpoonResults;
+
 	private FaultLocalizationFamily family;
 	//------Options for spectrum-based fault localization------
 	private SpectrumFormula spectrumFormula;
@@ -89,6 +91,8 @@ public class FlacocoConfig {
 		this.jUnit5Tests = new HashSet<>();
 		this.jacocoIncludes = new HashSet<>();
 		this.jacocoExcludes = new HashSet<>();
+
+		this.computeSpoonResults = false;
 
 		this.family = FaultLocalizationFamily.SPECTRUM_BASED;
 		this.spectrumFormula = SpectrumFormula.OCHIAI;
@@ -322,6 +326,14 @@ public class FlacocoConfig {
 		this.complianceLevel = complianceLevel;
 	}
 
+	public boolean isComputeSpoonResults() {
+		return computeSpoonResults;
+	}
+
+	public void setComputeSpoonResults(boolean computeSpoonResults) {
+		this.computeSpoonResults = computeSpoonResults;
+	}
+
 	@Override
 	public String toString() {
 		return "FlacocoConfig{" +
@@ -350,6 +362,7 @@ public class FlacocoConfig {
 				", jacocoExcludes=" + jacocoExcludes +
 				", family=" + family +
 				", spectrumFormula=" + spectrumFormula +
+				", computeSpoonResults=" + computeSpoonResults +
 				'}';
 	}
 

--- a/src/main/java/fr/spoonlabs/flacoco/localization/FaultLocalizationRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/FaultLocalizationRunner.java
@@ -1,11 +1,9 @@
 package fr.spoonlabs.flacoco.localization;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
-
-import java.util.Map;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 
 public interface FaultLocalizationRunner {
 
-	Map<String, Suspiciousness> run();
+    FlacocoResult run();
 
 }

--- a/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunner.java
@@ -32,7 +32,7 @@ public class SpectrumRunner implements FaultLocalizationRunner {
         result.setDefaultSuspiciousnessMap(defaultMapping);
 
         if (config.isComputeSpoonResults()) {
-            result.setSpoonSuspiciousnessMap(SpoonConverter.convert(defaultMapping));
+            result = SpoonConverter.convertResult(result);
         }
 
         return result;

--- a/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
+++ b/src/main/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputation.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.localization.spectrum;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.coverage.CoverageMatrix;
 import fr.spoonlabs.flacoco.core.test.method.TestMethod;
@@ -27,18 +28,18 @@ public class SpectrumSuspiciousComputation {
 	 * @return a map where the keys are the lines and the values are the suspicious
 	 * values
 	 */
-	public Map<String, Suspiciousness> calculateSuspicious(CoverageMatrix matrix, Formula formula) {
+	public Map<Location, Suspiciousness> calculateSuspicious(CoverageMatrix matrix, Formula formula) {
 
-		Map<String, Suspiciousness> result = new HashMap<>();
+		Map<Location, Suspiciousness> result = new HashMap<>();
 		// For each line of code to analyze
-		for (String keyline : matrix.getResultExecution().keySet()) {
+		for (Location location : matrix.getResultExecution().keySet()) {
 			List<TestMethod> testsPassingExecuting = new ArrayList<>();
 			List<TestMethod> testsFailingExecuting = new ArrayList<>();
 
 			int nrTestPassingNotExecuting = 0;
 			int nrTestFailingNotExecuting = 0;
 
-			Set<TestMethod> currentExecution = matrix.getResultExecution().get(keyline);
+			Set<TestMethod> currentExecution = matrix.getResultExecution().get(location);
 
 			// For each test
 			for (TestMethod testMethod : matrix.getTests().keySet()) {
@@ -59,13 +60,13 @@ public class SpectrumSuspiciousComputation {
 			Double score = formula.compute(nrTestPassingNotExecuting, nrTestFailingNotExecuting,
 					testsPassingExecuting.size(), testsFailingExecuting.size());
 
-			result.put(keyline, new Suspiciousness(score, testsPassingExecuting, testsFailingExecuting));
+			result.put(location, new Suspiciousness(score, testsPassingExecuting, testsFailingExecuting));
 		}
 
 		// Filter according to threshold, sort by suspicious and return
 		return result.entrySet().stream()
 				.filter(x -> x.getValue().getScore() >= config.getThreshold() && (x.getValue().getScore() > 0.0 || config.isIncludeZeros()))
-				.sorted(Map.Entry.<String, Suspiciousness>comparingByValue().reversed())
+				.sorted(Map.Entry.<Location, Suspiciousness>comparingByValue().reversed())
 				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
 
 	}

--- a/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
@@ -1,5 +1,6 @@
 package fr.spoonlabs.flacoco.utils.spoon;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.api.result.Location;
 import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
@@ -21,9 +22,8 @@ public class SpoonConverter {
 	private static Logger logger = Logger.getLogger(SpoonConverter.class);
 	private static FlacocoConfig config = FlacocoConfig.getInstance();
 
-	public static Map<CtStatement, Suspiciousness> convert(Map<Location, Suspiciousness> original) {
+	public static FlacocoResult convertResult(FlacocoResult flacocoResult) {
 		logger.debug("Converting results to Spoon format...");
-		logger.debug(original);
 
 		// Init spoon Launcher
 		Launcher launcher = new Launcher();
@@ -36,6 +36,8 @@ public class SpoonConverter {
 
 		// Convert keys
 		Map<CtStatement, Suspiciousness> result = new HashMap<>();
+		Map<Location, CtStatement> mapping = new HashMap<>();
+		Map<Location, Suspiciousness> original = flacocoResult.getDefaultSuspiciousnessMap();
 		for (Location location : original.keySet()) {
 			// Compute location information
 			SpoonLocalizedFaultFinder.fullyQualifiedClassName = location.getClassName();
@@ -58,12 +60,15 @@ public class SpoonConverter {
 						"Flacoco on https://github.com/SpoonLabs/flacoco");
 			}
 			result.put(SpoonLocalizedFaultFinder.found, original.get(location));
+			mapping.put(location, SpoonLocalizedFaultFinder.found);
 
 			// Prepare for next key
 			SpoonLocalizedFaultFinder.found = null;
 		}
 
-		return result;
+		flacocoResult.setSpoonSuspiciousnessMap(result);
+		flacocoResult.setLocationStatementMap(mapping);
+		return flacocoResult;
 	}
 
 }

--- a/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
+++ b/src/main/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverter.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.utils.spoon;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import org.apache.log4j.Logger;
 import spoon.Launcher;
@@ -20,7 +21,7 @@ public class SpoonConverter {
 	private static Logger logger = Logger.getLogger(SpoonConverter.class);
 	private static FlacocoConfig config = FlacocoConfig.getInstance();
 
-	public static Map<CtStatement, Suspiciousness> convert(Map<String, Suspiciousness> original) {
+	public static Map<CtStatement, Suspiciousness> convert(Map<Location, Suspiciousness> original) {
 		logger.debug("Converting results to Spoon format...");
 		logger.debug(original);
 
@@ -35,11 +36,10 @@ public class SpoonConverter {
 
 		// Convert keys
 		Map<CtStatement, Suspiciousness> result = new HashMap<>();
-		for (String key : original.keySet()) {
+		for (Location location : original.keySet()) {
 			// Compute location information
-			SpoonLocalizedFaultFinder.fullyQualifiedClassName = key.substring(0, key.indexOf("@"))
-					.replace("/", ".");
-			SpoonLocalizedFaultFinder.lineNumber = Integer.parseInt(key.substring(key.lastIndexOf("@") + 1));
+			SpoonLocalizedFaultFinder.fullyQualifiedClassName = location.getClassName();
+			SpoonLocalizedFaultFinder.lineNumber = location.getLineNumber();
 
 			// Launch processor to find the top-most CtStatement of the given line
 			launcher.process();
@@ -52,12 +52,12 @@ public class SpoonConverter {
 
 			// Warning message that should never occur.
 			if (result.containsKey(SpoonLocalizedFaultFinder.found) &&
-					!result.get(SpoonLocalizedFaultFinder.found).equals(original.get(key))) {
-				logger.error("Converting [" + key + "] to [" + SpoonLocalizedFaultFinder.found + "] resulted in a " +
+					!result.get(SpoonLocalizedFaultFinder.found).equals(original.get(location))) {
+				logger.error("Converting [" + location + "] to [" + SpoonLocalizedFaultFinder.found + "] resulted in a " +
 						"duplicate key with different suspiciouness values. Please report this to the developers of " +
 						"Flacoco on https://github.com/SpoonLabs/flacoco");
 			}
-			result.put(SpoonLocalizedFaultFinder.found, original.get(key));
+			result.put(SpoonLocalizedFaultFinder.found, original.get(location));
 
 			// Prepare for next key
 			SpoonLocalizedFaultFinder.found = null;

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -4,6 +4,7 @@ import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.api.result.Location;
 import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
+import fr.spoonlabs.flacoco.core.test.method.StringTestMethod;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
@@ -57,6 +58,9 @@ public class FlacocoTest {
 
 		// Run default mode
 		FlacocoResult result = flacoco.run();
+
+		assertEquals(1, result.getFailingTests().size());
+		assertTrue(result.getFailingTests().contains(new StringTestMethod("fr.spoonlabs.FLtest1.CalculatorTest", "testMul")));
 
 		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
 			System.out.println(entry);
@@ -390,6 +394,9 @@ public class FlacocoTest {
 		// Run default mode
 		FlacocoResult result = flacoco.run();
 
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(6, mapping.size());
+
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement
 		assertEquals(5, susp.size());
@@ -544,6 +551,9 @@ public class FlacocoTest {
 		// Run default mode
 		FlacocoResult result = flacoco.run();
 
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(4, mapping.size());
+
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
@@ -655,6 +665,9 @@ public class FlacocoTest {
 
 		// Run default mode
 		FlacocoResult result = flacoco.run();
+
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(4, mapping.size());
 
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
@@ -809,6 +822,9 @@ public class FlacocoTest {
 
 		// Run default mode
 		FlacocoResult result = flacoco.run();
+
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(4, mapping.size());
 
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
@@ -972,6 +988,9 @@ public class FlacocoTest {
 		// Run default mode
 		FlacocoResult result = flacoco.run();
 
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(6, mapping.size());
+
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement
 		assertEquals(5, susp.size());
@@ -1058,6 +1077,9 @@ public class FlacocoTest {
 
 		// Run default mode
 		FlacocoResult result = flacoco.run();
+
+		Map<Location, CtStatement> mapping = result.getLocationStatementMap();
+		assertEquals(6, mapping.size());
 
 		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -1,5 +1,8 @@
 package fr.spoonlabs.flacoco.api;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.log4j.Level;
@@ -53,25 +56,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -87,21 +91,22 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		// no lines below to 0.51 in suspiciousness are returned
 		assertEquals(3, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 	}
 
 	@Test
@@ -118,32 +123,33 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		// all lines are returned
 		assertEquals(10, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 
 		// Lines with no failing test executing them have a 0.0 score
-		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@11").getScore(), 0);
-		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@13").getScore(), 0);
-		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0);
-		assertEquals(0.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0);
+		assertEquals(0.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 11)).getScore(), 0);
+		assertEquals(0.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 13)).getScore(), 0);
+		assertEquals(0.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0);
+		assertEquals(0.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 17)).getScore(), 0);
 	}
 
 	@Test
@@ -165,25 +171,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -200,18 +207,19 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		// all executed lines are returned
 		assertEquals(9, susp.size());
 
 		// and they all have zero suspiciousness, since we ignored the failing test case
-		for (String line : susp.keySet()) {
-			assertEquals(0.0, susp.get(line).getScore(), 0);
+		for (Location location : susp.keySet()) {
+			assertEquals(0.0, susp.get(location).getScore(), 0);
 		}
 	}
 
@@ -231,27 +239,28 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(8, susp.keySet().size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@22").getScore(), 0); // exception thrown here
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 21)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 22)).getScore(), 0); // exception thrown here
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@18").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 18)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0);
 
 		// Lines executed by all test
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	@Test
@@ -266,26 +275,27 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.keySet().size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 21)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@18").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 18)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0);
 
 		// Lines executed by all test
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	@Test
@@ -301,28 +311,29 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(9, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	/**
@@ -342,25 +353,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -370,13 +382,15 @@ public class FlacocoTest {
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement
 		assertEquals(5, susp.size());
 
@@ -418,23 +432,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -457,23 +472,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -490,26 +506,27 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -519,13 +536,15 @@ public class FlacocoTest {
 		config.setProjectPath(new File("./examples/exampleFL4JUnit5/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
@@ -565,23 +584,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -598,26 +618,27 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -627,13 +648,15 @@ public class FlacocoTest {
 		config.setProjectPath(new File("./examples/exampleFL5JUnit3/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
@@ -673,23 +696,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -714,23 +738,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -747,26 +772,27 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.size());
 
-		// Line executed only by the failing (including the test itself)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -776,13 +802,15 @@ public class FlacocoTest {
 		config.setProjectPath(new File("./examples/exampleFL6Mixed/FLtest1").getAbsolutePath());
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		for (CtStatement ctStatement : susp.keySet()) {
@@ -822,25 +850,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -860,25 +889,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -898,28 +928,29 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(9, susp.size());
 
-		// Line executed only by the failing (including the test itself)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -933,13 +964,15 @@ public class FlacocoTest {
 		config.setBinTestDir(Collections.singletonList("./examples/exampleFL8NotMaven/bin/test-classes"));
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement
 		assertEquals(5, susp.size());
 
@@ -985,25 +1018,26 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -1017,13 +1051,15 @@ public class FlacocoTest {
 		config.setBinTestDir(Arrays.asList("./examples/exampleFL9NotMavenMultiple/bin/test-classes2", "./examples/exampleFL9NotMavenMultiple/bin/test-classes1"));
 		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setComputeSpoonResults(true);
 
 		// Run Flacoco
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<CtStatement, Suspiciousness> susp = flacoco.runSpoon();
+		FlacocoResult result = flacoco.run();
 
+		Map<CtStatement, Suspiciousness> susp = result.getSpoonSuspiciousnessMap();
 		// The two lines of the (empty) constructor get mapped to the same CtStatement
 		assertEquals(5, susp.size());
 
@@ -1065,29 +1101,30 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(8, susp.size());
 
 		// Line executed by all failing test cases
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.0);
 
 		// Line executed by one passing and 2 failing tests
-		assertEquals(0.81, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.81, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by one failing test
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 17)).getScore(), 0.01);
 
 		// Line executed by all tests (2 passing, 2 failing)
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	/**
@@ -1110,23 +1147,24 @@ public class FlacocoTest {
 		Flacoco flacoco = new Flacoco();
 
 		// Run default mode
-		Map<String, Suspiciousness> susp = flacoco.runDefault();
+		FlacocoResult result = flacoco.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("" + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 10)).getScore(), 0);
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
@@ -1,5 +1,8 @@
 package fr.spoonlabs.flacoco.api;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.coverage.framework.JUnit4Strategy;
 import fr.spoonlabs.flacoco.core.test.TestContext;
@@ -56,22 +59,23 @@ public class Math70Test {
         Flacoco flacoco = new Flacoco();
 
         // Run default mode
-        Map<String, Suspiciousness> susp = flacoco.runDefault();
+        FlacocoResult result = flacoco.run();
 
-        for (String line : susp.keySet()) {
-            System.out.println("" + line + " " + susp.get(line));
+        for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+            System.out.println(entry);
         }
 
+        Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
         assertEquals(8, susp.size());
 
-        assertEquals(1.0, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@72").getScore(), 0);
-        assertEquals(0.70, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@66").getScore(), 0.01);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@81").getScore(), 0);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@80").getScore(), 0);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@89").getScore(), 0);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@88").getScore(), 0);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@87").getScore(), 0);
-        assertEquals(0.5, susp.get("org/apache/commons/math/analysis/solvers/BisectionSolver@-@87").getScore(), 0);
+        assertEquals(1.0, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 72)).getScore(), 0);
+        assertEquals(0.70, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 66)).getScore(), 0.01);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 81)).getScore(), 0);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 80)).getScore(), 0);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 89)).getScore(), 0);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 88)).getScore(), 0);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 87)).getScore(), 0);
+        assertEquals(0.5, susp.get(new Location("org.apache.commons.math.analysis.solvers.BisectionSolver", 87)).getScore(), 0);
     }
 
 

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.core.coverage;
 
 import eu.stamp_project.testrunner.EntryPoint;
+import fr.spoonlabs.flacoco.api.result.Location;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.test.TestContext;
 import fr.spoonlabs.flacoco.core.test.TestDetector;
@@ -62,7 +63,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -76,7 +77,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -86,7 +87,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -99,7 +100,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -109,7 +110,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -120,7 +121,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -131,7 +132,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -163,16 +164,16 @@ public class CoverageRunnerTest {
 		assertEquals(12, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(5, firstLineExecuted.size());
 
-		Set<TestMethod> secondLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> secondLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertEquals(2, secondLineExecuted.size());
 
 
 		// This line is the one that throws an exception
 		System.out.println(matrix.getResultExecution());
-		Set<TestMethod> exceptionThrower = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@22");
+		Set<TestMethod> exceptionThrower = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 22));
 		assertEquals(1, exceptionThrower.size());
 	}
 
@@ -200,14 +201,14 @@ public class CoverageRunnerTest {
 		assertEquals(11, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		// The assertion fails because it cannot count the erroring test
 		assertEquals(5, firstLineExecuted.size());
 
-		Set<TestMethod> secondLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@21");
+		Set<TestMethod> secondLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 21));
 		assertEquals(1, secondLineExecuted.size());
 
-		Set<TestMethod> failingLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@22");
+		Set<TestMethod> failingLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 22));
 		assertNull(failingLineExecuted);
 		// assertEquals(0, failingLineExecuted.size());
 	}
@@ -238,7 +239,7 @@ public class CoverageRunnerTest {
 		assertEquals(19, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -275,7 +276,7 @@ public class CoverageRunnerTest {
 		assertEquals(8, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -289,7 +290,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -299,7 +300,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -312,7 +313,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -322,7 +323,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -333,7 +334,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -344,7 +345,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -372,7 +373,7 @@ public class CoverageRunnerTest {
 		assertEquals(8, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -386,7 +387,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -396,7 +397,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -409,7 +410,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -419,7 +420,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -430,7 +431,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -441,7 +442,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -469,7 +470,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -483,7 +484,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorMixedTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -493,7 +494,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorJUnit3Test#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -506,7 +507,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorJUnit5Test#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorMixedTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -516,7 +517,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorMixedTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -527,7 +528,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorMixedTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorJUnit5Test#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -538,7 +539,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorJUnit5Test#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -586,7 +587,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -600,7 +601,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -610,7 +611,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -623,7 +624,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -633,7 +634,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -644,7 +645,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -655,7 +656,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -683,7 +684,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(8, firstLineExecuted.size());
 
@@ -697,7 +698,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -707,7 +708,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(6, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -720,7 +721,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(4, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -730,7 +731,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(2, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -741,7 +742,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(2, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -752,7 +753,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -785,7 +786,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -799,7 +800,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -809,7 +810,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -822,7 +823,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -832,7 +833,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -843,7 +844,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -854,7 +855,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -886,7 +887,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(8, firstLineExecuted.size());
 
@@ -900,7 +901,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -910,7 +911,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(6, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -923,7 +924,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(4, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -933,7 +934,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(2, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -944,7 +945,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(2, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -955,7 +956,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -983,7 +984,7 @@ public class CoverageRunnerTest {
 		assertEquals(10, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -997,7 +998,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1007,7 +1008,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -1020,7 +1021,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1030,7 +1031,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -1041,7 +1042,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1052,7 +1053,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.Calculator", 18));
 		assertNull(modCond);
 	}
 
@@ -1085,7 +1086,7 @@ public class CoverageRunnerTest {
 		assertEquals(8, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
-		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@10");
+		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 10));
 
 		assertEquals(4, firstLineExecuted.size());
 
@@ -1099,7 +1100,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testMul"));
 
 		// This one is only executed by the sum
-		Set<TestMethod> returnSum = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@11");
+		Set<TestMethod> returnSum = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 11));
 
 		executedTestKeys = returnSum.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1109,7 +1110,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testSum"));
 
 		// This line is the second if, so it's covered by all tests, except the first one
-		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@12");
+		Set<TestMethod> secondIfExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 12));
 		assertEquals(3, secondIfExecuted.size());
 
 		executedTestKeys = secondIfExecuted.stream()
@@ -1122,7 +1123,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testDiv"));
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testMul"));
 
-		Set<TestMethod> oneMultCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@14");
+		Set<TestMethod> oneMultCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 14));
 		assertEquals(2, oneMultCond.size());
 		executedTestKeys = oneMultCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1132,7 +1133,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testMul"));
 
 		// This line is inside one if, so it's executed only one
-		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@15");
+		Set<TestMethod> oneReturnLineExecuted = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 15));
 		assertEquals(1, oneReturnLineExecuted.size());
 
 		executedTestKeys = oneReturnLineExecuted.stream()
@@ -1143,7 +1144,7 @@ public class CoverageRunnerTest {
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testSubs"));
 		assertFalse(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testDiv"));
 
-		Set<TestMethod> divisionCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@16");
+		Set<TestMethod> divisionCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 16));
 		assertEquals(1, divisionCond.size());
 		executedTestKeys = divisionCond.stream()
 				.map(TestMethod::getFullyQualifiedMethodName).collect(Collectors.toSet());
@@ -1154,7 +1155,7 @@ public class CoverageRunnerTest {
 		assertTrue(executedTestKeys.contains("fr.spoonlabs.FLtest1.enum.CalculatorTest#testDiv"));
 
 		// Any test executes that
-		Set<TestMethod> modCond = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/enum/Calculator@-@18");
+		Set<TestMethod> modCond = matrix.getResultExecution().get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 18));
 		assertNull(modCond);
 	}
 

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -1,6 +1,8 @@
 package fr.spoonlabs.flacoco.localization.spectrum;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
@@ -42,25 +44,26 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -72,27 +75,28 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(8, susp.keySet().size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@22").getScore(), 0); // exception thrown here
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 21)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 22)).getScore(), 0); // exception thrown here
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@18").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 18)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0);
 
 		// Lines executed by all test
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	@Test
@@ -104,26 +108,27 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.keySet().size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@21").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 21)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@18").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 18)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0);
 
 		// Lines executed by all test
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.44, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.44, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	@Test
@@ -136,28 +141,29 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(9, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -169,23 +175,24 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -199,26 +206,27 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -230,23 +238,24 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -260,26 +269,27 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
-		assertEquals(7, susp.size());
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
+		assertEquals(6, susp.size());
 
-		// Line executed only by the failing (including the call form the test)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -291,23 +301,24 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -321,26 +332,27 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(7, susp.size());
 
-		// Line executed only by the failing (including the test itself)
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 28)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@9").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@7").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 9)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.CalculatorTest", 7)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
 	}
 
 	@Test
@@ -352,25 +364,26 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -386,25 +399,26 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -420,25 +434,26 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(6, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0);
 	}
 
 	@Test
@@ -450,29 +465,30 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(8, susp.size());
 
 		// Line executed by all failing test cases
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)).getScore(), 0.0);
 
 		// Line executed by one passing and 2 failing tests
-		assertEquals(0.81, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.81, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by one failing test
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@16").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@17").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 16)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 17)).getScore(), 0.01);
 
 		// Line executed by all tests (2 passing, 2 failing)
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0.01);
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 10)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)).getScore(), 0.01);
 	}
 
 	@Test
@@ -489,23 +505,24 @@ public class SpectrumRunnerTest {
 
 		SpectrumRunner runner = new SpectrumRunner();
 
-		Map<String, Suspiciousness> susp = runner.run();
+		FlacocoResult result = runner.run();
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
+			System.out.println(entry);
 		}
 
+		Map<Location, Suspiciousness> susp = result.getDefaultSuspiciousnessMap();
 		assertEquals(4, susp.size());
 
 		// Line executed only by the failing
-		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 15)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@14").getScore(), 0.01);
-		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@12").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 14)).getScore(), 0.01);
+		assertEquals(0.57, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 12)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/enum/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get(new Location("fr.spoonlabs.FLtest1.enum.Calculator", 10)).getScore(), 0);
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputationTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumSuspiciousComputationTest.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.localization.spectrum;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.coverage.CoverageMatrix;
 import fr.spoonlabs.flacoco.core.test.method.TestMethod;
 import fr.spoonlabs.flacoco.localization.spectrum.formulas.OchiaiFormula;
@@ -24,28 +25,28 @@ public class SpectrumSuspiciousComputationTest {
 		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test1");
 		when(testMethod.toString()).thenReturn("test1");
 		for (int i = 0; i <= 4; i++) {
-			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, true);
+			exampleCoverageMatrix.add(new Location("test", i), testMethod, i, true);
 		}
 		// test@-@[1,6] are ran in a failing test case
 		testMethod = mock(TestMethod.class);
 		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test2");
 		when(testMethod.toString()).thenReturn("test2");
 		for (int i = 0; i <= 6; i++) {
-			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, false);
+			exampleCoverageMatrix.add(new Location("test", i), testMethod, i, false);
 		}
 		// test@-@[1,9] are ran in a failing test case
 		testMethod = mock(TestMethod.class);
 		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test4");
 		when(testMethod.toString()).thenReturn("test4");
 		for (int i = 0; i <= 9; i++) {
-			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, false);
+			exampleCoverageMatrix.add(new Location("test", i), testMethod, i, false);
 		}
 		// test@-@[1,5] are ran in a passing test case
 		testMethod = mock(TestMethod.class);
 		when(testMethod.getFullyQualifiedMethodName()).thenReturn("test3");
 		when(testMethod.toString()).thenReturn("test3");
 		for (int i = 1; i <= 5; i++) {
-			exampleCoverageMatrix.add("test@-@" + i, testMethod, i, true);
+			exampleCoverageMatrix.add(new Location("test", i), testMethod, i, true);
 		}
 	}
 
@@ -53,30 +54,30 @@ public class SpectrumSuspiciousComputationTest {
 	public void testOchiaiComputation() {
 		SpectrumSuspiciousComputation comp = new SpectrumSuspiciousComputation();
 
-		Map<String, Suspiciousness> susp = comp.calculateSuspicious(exampleCoverageMatrix, new OchiaiFormula());
+		Map<Location, Suspiciousness> susp = comp.calculateSuspicious(exampleCoverageMatrix, new OchiaiFormula());
 
-		for (String line : susp.keySet()) {
-			System.out.println("susp " + line + " " + susp.get(line));
+		for (Map.Entry<Location, Suspiciousness> entry : susp.entrySet()) {
+			System.out.println(entry);
 		}
 
 		assertEquals(9, susp.size());
 
 		// Line executed by all the failing test cases
-		assertEquals(1.0, susp.get("test@-@6").getScore(), 0);
+		assertEquals(1.0, susp.get(new Location("test", 6)).getScore(), 0);
 
 		// Line executed by a mix of failing and passing
-		assertEquals(0.81, susp.get("test@-@5").getScore(), 0.01);
+		assertEquals(0.81, susp.get(new Location("test", 5)).getScore(), 0.01);
 
 		// Lines executed by just one failing test
-		assertEquals(0.70, susp.get("test@-@9").getScore(), 0.01);
-		assertEquals(0.70, susp.get("test@-@8").getScore(), 0.01);
-		assertEquals(0.70, susp.get("test@-@7").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 9)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 8)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 7)).getScore(), 0.01);
 
 		// Lines executed by all test
-		assertEquals(0.70, susp.get("test@-@4").getScore(), 0.01);
-		assertEquals(0.70, susp.get("test@-@3").getScore(), 0.01);
-		assertEquals(0.70, susp.get("test@-@2").getScore(), 0.01);
-		assertEquals(0.70, susp.get("test@-@1").getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 4)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 3)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 2)).getScore(), 0.01);
+		assertEquals(0.70, susp.get(new Location("test", 1)).getScore(), 0.01);
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
@@ -37,6 +37,7 @@ public class SpoonConverterTest {
 	}
 
 	@Test
+	@Ignore
 	public void testConvertSpoonExample() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();

--- a/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
@@ -1,5 +1,6 @@
 package fr.spoonlabs.flacoco.utils.spoon;
 
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
 import fr.spoonlabs.flacoco.api.result.Location;
 import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
@@ -36,7 +37,6 @@ public class SpoonConverterTest {
 	}
 
 	@Test
-	@Ignore
 	public void testConvertSpoonExample() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -45,6 +45,7 @@ public class SpoonConverterTest {
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
 		// Init mapping
+		FlacocoResult flacocoResult = new FlacocoResult();
 		Map<Location, Suspiciousness> map = new HashMap<>();
 		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 5), new Suspiciousness(1.0, null, null));
 		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 6), new Suspiciousness(0.95, null, null));
@@ -54,41 +55,57 @@ public class SpoonConverterTest {
 		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 15), new Suspiciousness(0.75, null, null));
 		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 26), new Suspiciousness(0.70, null, null));
 		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 21), new Suspiciousness(0.65, null, null));
+		flacocoResult.setDefaultSuspiciousnessMap(map);
 
-		Map<CtStatement, Suspiciousness> converted = SpoonConverter.convert(map);
+		flacocoResult = SpoonConverter.convertResult(flacocoResult);
+		Map<CtStatement, Suspiciousness> converted = flacocoResult.getSpoonSuspiciousnessMap();
+		Map<Location, CtStatement> locationToStatement = flacocoResult.getLocationStatementMap();
 
 		for (CtStatement statement : converted.keySet()) {
 			System.out.println(statement + " : " + converted.get(statement));
 		}
 
+		for (Location location : locationToStatement.keySet()) {
+			System.out.println(location + " : " + locationToStatement.get(location));
+		}
+
 		// Even though we had 8 keys, we now have 7 as two of them map to the same CtStatement
 		assertEquals(7, converted.size());
+		assertEquals(8, locationToStatement.size());
 
 		for (CtStatement statement : converted.keySet()) {
 			switch (statement.getPosition().getLine()) {
 				case 12:
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 12)), statement);
 					assertEquals("op.equals(\"+\")", statement.toString());
 					break;
 				case 14:
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 14)), statement);
 					assertEquals("op.equals(\"-\")", statement.toString());
 					break;
 				case 15:
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 15)), statement);
 					assertEquals("return op1 - op2", statement.toString());
 					break;
 				case 26:
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 26)), statement);
 					assertEquals("throw new java.lang.UnsupportedOperationException(op)", statement.toString());
 					break;
 				case 5:
 					// This is the case where two keys get mapped to just one statement
 					// In this case, it is an empty constructor
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 5)), statement);
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 6)), statement);
 					assertEquals("{\n}", statement.toString());
 					break;
 				case 3:
 					// Here we get the whole class as there is no CtStatement for the field init
 					// Line 8 gets mapped to 3
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 8)), statement);
 					assertTrue(statement.toString().startsWith("public class Calculator {\n"));
 					break;
 				case 21:
+					assertEquals(locationToStatement.get(new Location("fr.spoonlabs.FLtest1.Calculator", 21)), statement);
 					assertTrue(statement.toString().startsWith("java.lang.System.out.println"));
 					break;
 			}

--- a/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
@@ -1,6 +1,7 @@
 package fr.spoonlabs.flacoco.utils.spoon;
 
-import fr.spoonlabs.flacoco.api.Suspiciousness;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
 import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.log4j.Level;
@@ -44,15 +45,15 @@ public class SpoonConverterTest {
 		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
 
 		// Init mapping
-		Map<String, Suspiciousness> map = new HashMap<>();
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@5", new Suspiciousness(1.0, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@6", new Suspiciousness(0.95, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@12", new Suspiciousness(0.90, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@8", new Suspiciousness(0.85, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@14", new Suspiciousness(0.80, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@15", new Suspiciousness(0.75, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@26", new Suspiciousness(0.70, null, null));
-		map.put("fr/spoonlabs/FLtest1/Calculator@-@21", new Suspiciousness(0.65, null, null));
+		Map<Location, Suspiciousness> map = new HashMap<>();
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 5), new Suspiciousness(1.0, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 6), new Suspiciousness(0.95, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 12), new Suspiciousness(0.90, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 8), new Suspiciousness(0.85, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 14), new Suspiciousness(0.80, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 15), new Suspiciousness(0.75, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 26), new Suspiciousness(0.70, null, null));
+		map.put(new Location("fr.spoonlabs.FLtest1.Calculator", 21), new Suspiciousness(0.65, null, null));
 
 		Map<CtStatement, Suspiciousness> converted = SpoonConverter.convert(map);
 

--- a/src/test/resources/OneLineExporter.java
+++ b/src/test/resources/OneLineExporter.java
@@ -1,3 +1,7 @@
+import fr.spoonlabs.flacoco.api.result.FlacocoResult;
+import fr.spoonlabs.flacoco.api.result.Location;
+import fr.spoonlabs.flacoco.api.result.Suspiciousness;
+
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.Map;
@@ -5,8 +9,8 @@ import java.util.Map;
 public class OneLineExporter implements fr.spoonlabs.flacoco.cli.export.FlacocoExporter {
 
 	@Override
-	public void export(Map<String, fr.spoonlabs.flacoco.api.Suspiciousness> results, OutputStreamWriter outputStream) throws IOException {
-		for (Map.Entry<String, fr.spoonlabs.flacoco.api.Suspiciousness> entry : results.entrySet()) {
+	public void export(FlacocoResult result, OutputStreamWriter outputStream) throws IOException {
+		for (Map.Entry<Location, Suspiciousness> entry : result.getDefaultSuspiciousnessMap().entrySet()) {
 			outputStream.write(entry.getKey() + "," + entry.getValue().getScore());
 		}
 	}

--- a/src/test/resources/expected.csv
+++ b/src/test/resources/expected.csv
@@ -1,6 +1,6 @@
-fr/spoonlabs/FLtest1/Calculator@-@15,1.0
-fr/spoonlabs/FLtest1/Calculator@-@14,0.7071067811865475
-fr/spoonlabs/FLtest1/Calculator@-@12,0.5773502691896258
-fr/spoonlabs/FLtest1/Calculator@-@5,0.5
-fr/spoonlabs/FLtest1/Calculator@-@6,0.5
-fr/spoonlabs/FLtest1/Calculator@-@10,0.5
+fr.spoonlabs.FLtest1.Calculator@-@15,1.0
+fr.spoonlabs.FLtest1.Calculator@-@14,0.7071067811865475
+fr.spoonlabs.FLtest1.Calculator@-@12,0.5773502691896258
+fr.spoonlabs.FLtest1.Calculator@-@5,0.5
+fr.spoonlabs.FLtest1.Calculator@-@6,0.5
+fr.spoonlabs.FLtest1.Calculator@-@10,0.5

--- a/src/test/resources/expected.custom
+++ b/src/test/resources/expected.custom
@@ -1,1 +1,1 @@
-fr/spoonlabs/FLtest1/Calculator@-@15,1.0fr/spoonlabs/FLtest1/Calculator@-@14,0.7071067811865475fr/spoonlabs/FLtest1/Calculator@-@12,0.5773502691896258fr/spoonlabs/FLtest1/Calculator@-@5,0.5fr/spoonlabs/FLtest1/Calculator@-@6,0.5fr/spoonlabs/FLtest1/Calculator@-@10,0.5
+fr.spoonlabs.FLtest1.Calculator@-@15,1.0fr.spoonlabs.FLtest1.Calculator@-@14,0.7071067811865475fr.spoonlabs.FLtest1.Calculator@-@12,0.5773502691896258fr.spoonlabs.FLtest1.Calculator@-@5,0.5fr.spoonlabs.FLtest1.Calculator@-@6,0.5fr.spoonlabs.FLtest1.Calculator@-@10,0.5

--- a/src/test/resources/expected.json
+++ b/src/test/resources/expected.json
@@ -1,1 +1,1 @@
-{"fr/spoonlabs/FLtest1/Calculator@-@15":1.0,"fr/spoonlabs/FLtest1/Calculator@-@14":0.7071067811865475,"fr/spoonlabs/FLtest1/Calculator@-@12":0.5773502691896258,"fr/spoonlabs/FLtest1/Calculator@-@5":0.5,"fr/spoonlabs/FLtest1/Calculator@-@6":0.5,"fr/spoonlabs/FLtest1/Calculator@-@10":0.5}
+{"fr.spoonlabs.FLtest1.Calculator@-@15":1.0,"fr.spoonlabs.FLtest1.Calculator@-@14":0.7071067811865475,"fr.spoonlabs.FLtest1.Calculator@-@12":0.5773502691896258,"fr.spoonlabs.FLtest1.Calculator@-@5":0.5,"fr.spoonlabs.FLtest1.Calculator@-@6":0.5,"fr.spoonlabs.FLtest1.Calculator@-@10":0.5}


### PR DESCRIPTION
Closes #88 

Flacoco would work like this:

- Only one entrypoint, the `run` method of `Flacoco`.
- The result is always the same object type `FlacocoResult`. This class encapsulates the information we have now, and possibly more information in the future.
- The Spoon mode is now available through a config option in `FlacocoConfig`. Set the option there, and the results will be available in `FlacocoResult` along side the default.
- The default result's key if now a `Location` object, which for now contains a class name and a line number.
- The class name in the default key is now separated by `.` as usual, not by `/` as we have been considering.

Any suggestion? This should be the definitive output format of `flacoco` and where we will build on top of.