### PR TITLE
Fix test coverage for JUnit4 tests

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
@@ -63,7 +63,8 @@ public class CoverageMatrix {
 		// Let's navigate the covered class per line.
 		for (String iClassNameCovered : covLine.getDetailedCoverage().keySet()) {
 
-			if (!config.isCoverTests() && testClasses.contains(iClassNameCovered)) {
+			String className = iClassNameCovered.replace("/", ".");
+			if (!config.isCoverTests() && testClasses.contains(className)) {
 				continue;
 			}
 
@@ -98,6 +99,11 @@ public class CoverageMatrix {
 						// computation, which will ignore classes like org.junit.Assert
 						if (((CoverageDetailed) result.getCoverageOf(testMethod.getFullyQualifiedMethodName()))
 								.getDetailedCoverage().containsKey(element.getClassName().replace(".", "/"))) {
+
+							// We also want to ignore test classes if they coverTests is not set
+							if (!config.isCoverTests() && testClasses.contains(element.getClassName())) {
+								continue;
+							}
 
 							String lineKey = CoverageMatrix.getLineKey(
 									element.getClassName().replace(".", "/"),

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageMatrix.java
@@ -5,6 +5,7 @@ import ch.scheitlin.alex.java.StackTraceParser;
 import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
 import eu.stamp_project.testrunner.listener.impl.CoverageDetailed;
 import eu.stamp_project.testrunner.listener.impl.CoverageFromClass;
+import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
 import fr.spoonlabs.flacoco.core.test.method.TestMethod;
 import org.apache.log4j.Logger;
 
@@ -48,7 +49,8 @@ public class CoverageMatrix {
 	 *
 	 * @param iCovWrapper
 	 */
-	public void processSingleTest(CoverageFromSingleTestUnit iCovWrapper) {
+	public void processSingleTest(CoverageFromSingleTestUnit iCovWrapper, Set<String> testClasses) {
+		FlacocoConfig config = FlacocoConfig.getInstance();
 		CoverageDetailed covLine = iCovWrapper.getCov();
 
 		if (iCovWrapper.isSkip()) {
@@ -60,6 +62,10 @@ public class CoverageMatrix {
 
 		// Let's navigate the covered class per line.
 		for (String iClassNameCovered : covLine.getDetailedCoverage().keySet()) {
+
+			if (!config.isCoverTests() && testClasses.contains(iClassNameCovered)) {
+				continue;
+			}
 
 			// Lines covered in that class
 			CoverageFromClass lines = covLine.getDetailedCoverage().get(iClassNameCovered);

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -7,7 +7,10 @@ import fr.spoonlabs.flacoco.core.test.method.TestMethod;
 import org.apache.log4j.Logger;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Class for running the coverage runner from test-runner and computing
@@ -24,6 +27,12 @@ public class CoverageRunner {
 		// This matrix stores the results: the execution of tests and the coverage of
 		// that execution on each line
 		CoverageMatrix matrixExecutionResult = new CoverageMatrix();
+
+		Set<String> testClasses = testContexts.stream()
+				.map(TestContext::getTestMethods)
+				.flatMap(List::stream)
+				.map(TestMethod::getFullyQualifiedClassName)
+				.collect(Collectors.toSet());
 
 		// For each test context
 		int executedTests = 0;
@@ -42,7 +51,7 @@ public class CoverageRunner {
 					testsFound++;
 
 					if (result.getCoverageResultsMap().containsKey(testMethod.getFullyQualifiedMethodName())) {
-						matrixExecutionResult.processSingleTest(new CoverageFromSingleTestUnit(testMethod, result));
+						matrixExecutionResult.processSingleTest(new CoverageFromSingleTestUnit(testMethod, result), testClasses);
 						executedTests++;
 					} else {
 						this.logger.warn("Test " + testMethod + " result was not reported by test-runner.");

--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/framework/TestFrameworkStrategy.java
@@ -40,9 +40,6 @@ public abstract class TestFrameworkStrategy {
 			EntryPoint.jacocoAgentExcludes =
 					config.getJacocoExcludes().stream().reduce((x, y) -> x + ":" + y).orElse("");
 		}
-		if (config.isCoverTests()) {
-			throw new UnsupportedOperationException();
-		}
 	}
 
 	/**
@@ -86,12 +83,18 @@ public abstract class TestFrameworkStrategy {
 
 	protected String computeJacocoIncludes() {
 		FlacocoConfig config = FlacocoConfig.getInstance();
-		String includes = "";
+		StringBuilder includes = new StringBuilder();
 		for (String directory : config.getBinJavaDir()) {
 			DirectoryScanner directoryScanner = new DirectoryScanner(new File(directory), TestListResolver.getWildcard());
-			includes = directoryScanner.scan().getClasses().stream().reduce((x, y) -> x + ":" + y).orElse("");
+			includes.append(":").append(directoryScanner.scan().getClasses().stream().reduce((x, y) -> x + ":" + y).orElse(""));
 		}
-		return includes;
+		if (config.isCoverTests()) {
+			for (String directory : config.getBinTestDir()) {
+				DirectoryScanner directoryScanner = new DirectoryScanner(new File(directory), TestListResolver.getWildcard());
+				includes.append(":").append(directoryScanner.scan().getClasses().stream().reduce((x, y) -> x + ":" + y).orElse(""));
+			}
+		}
+		return includes.toString();
 	}
 
 }

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -289,7 +289,6 @@ public class FlacocoTest {
 	}
 
 	@Test
-	@Ignore
 	public void testExampleFL1SpectrumBasedOchiaiCoverTestsDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -308,10 +307,11 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(9, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -400,6 +400,7 @@ public class FlacocoTest {
 	}
 
 	@Test
+	@Ignore
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiDefaultModeManualTestConfig() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -457,10 +458,11 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -564,10 +566,11 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -712,10 +715,11 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the test itself)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -840,7 +844,6 @@ public class FlacocoTest {
 	}
 
 	@Test
-	@Ignore
 	public void testExampleFL8SpectrumBasedOchiaiCoverTestsDefaultMode() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -863,10 +866,11 @@ public class FlacocoTest {
 			System.out.println("" + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(9, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the test itself)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -325,6 +325,44 @@ public class FlacocoTest {
 		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
 	}
 
+	/**
+	 * This test captures the cases where the test classes are included in the option `jacocoIncludes`
+	 * but the option `coverTests` is not set
+	 */
+	@Test
+	public void testExampleFL1SpectrumBasedOchiaiNoCoverTestsIncludesDefaultMode() {
+		// Setup config
+		FlacocoConfig config = FlacocoConfig.getInstance();
+		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
+		config.setFamily(FlacocoConfig.FaultLocalizationFamily.SPECTRUM_BASED);
+		config.setSpectrumFormula(SpectrumFormula.OCHIAI);
+		config.setJacocoIncludes(Collections.singleton("fr.spoonlabs.FLtest1.*"));
+
+		// Run Flacoco
+		Flacoco flacoco = new Flacoco();
+
+		// Run default mode
+		Map<String, Suspiciousness> susp = flacoco.runDefault();
+
+		for (String line : susp.keySet()) {
+			System.out.println("" + line + " " + susp.get(line));
+		}
+
+		assertEquals(6, susp.size());
+
+		// Line executed only by the failing
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+
+		// Line executed by a mix of failing and passing
+		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
+		assertEquals(0.57, susp.get("fr/spoonlabs/FLtest1/Calculator@-@12").getScore(), 0.01);
+
+		// Lines executed by all test
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@10").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@5").getScore(), 0);
+		assertEquals(0.5, susp.get("fr/spoonlabs/FLtest1/Calculator@-@6").getScore(), 0);
+	}
+
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiSpoonMode() {
 		// Setup config

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -213,7 +213,6 @@ public class CoverageRunnerTest {
 	}
 
 	@Test
-	@Ignore
 	public void testExampleFL1CoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -234,9 +233,9 @@ public class CoverageRunnerTest {
 		assertEquals(4, matrix.getTests().size());
 		assertEquals(1, matrix.getFailingTestCases().size());
 
-		// 16 executed lines
-		// We have 8 from class under test + 8 from test
-		assertEquals(16, matrix.getResultExecution().keySet().size());
+		// 19 executed lines
+		// We have 10 from class under test + 9 from tests
+		assertEquals(19, matrix.getResultExecution().keySet().size());
 
 		// This line is the first if, so it's covered by all tests
 		Set<TestMethod> firstLineExecuted = matrix.getResultExecution().get("fr/spoonlabs/FLtest1/Calculator@-@10");
@@ -249,7 +248,7 @@ public class CoverageRunnerTest {
 		config.setCoverTests(false);
 		matrix = detector.getCoverageMatrix(tests);
 
-		assertEquals(8, matrix.getResultExecution().keySet().size());
+		assertEquals(10, matrix.getResultExecution().keySet().size());
 	}
 
 	@Test

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -127,7 +127,6 @@ public class SpectrumRunnerTest {
 	}
 
 	@Test
-	@Ignore
 	public void testExampleFL1OchiaiCoverTests() {
 		// Setup config
 		FlacocoConfig config = FlacocoConfig.getInstance();
@@ -143,10 +142,11 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(8, susp.size());
+		assertEquals(9, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -205,10 +205,11 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -265,10 +266,11 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the call form the test)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);
@@ -325,10 +327,11 @@ public class SpectrumRunnerTest {
 			System.out.println("susp " + line + " " + susp.get(line));
 		}
 
-		assertEquals(6, susp.size());
+		assertEquals(7, susp.size());
 
-		// Line executed only by the failing
+		// Line executed only by the failing (including the test itself)
 		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/Calculator@-@15").getScore(), 0);
+		assertEquals(1.0, susp.get("fr/spoonlabs/FLtest1/CalculatorTest@-@28").getScore(), 0);
 
 		// Line executed by a mix of failing and passing
 		assertEquals(0.70, susp.get("fr/spoonlabs/FLtest1/Calculator@-@14").getScore(), 0.01);


### PR DESCRIPTION
This PR fixes the option `coverTests` but only for JUnit4 tests. For some, still unknown, reason, for JUnit5 and JUnit3 the coverage is not working. (#41 )

More importantly, this makes it so that test classes are excluded from the computation when the option is not set, even if they are included in the jacoco results. 

The implementation is an alternative to specifying them in the `excludes` option of jacoco, since that option quickly runs out of stack space (see #57 )