### PR TITLE
Include java 1 to 4 instruction sets in CI

### DIFF
--- a/.github/install_examples.sh
+++ b/.github/install_examples.sh
@@ -5,8 +5,8 @@ JAVA_MAJOR_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\./
 # Java version needs to be lower than 11, since support was dropped
 # If the source version is 1.1 OR 1.2, we can only install JUnit3 tests AND we need to use 1.3 as the source version since Java 8 does not support earlier versions
 if [ $JAVA_MAJOR_VERSION -lt "11" ] && ([ "$SRC_VERSION" = "1.1" ] || [ "$SRC_VERSION" = "1.2" ]); then
-    mvn clean test -DskipTests -Dmaven.compiler.source="1.2" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL5JUnit3/FLtest1/
-    mvn clean test -DskipTests -Dmaven.compiler.source="1.2" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL12Compliance4/FLtest1/
+    mvn clean test -DskipTests -Dmaven.compiler.source="1.3" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL5JUnit3/FLtest1/
+    mvn clean test -DskipTests -Dmaven.compiler.source="1.3" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL12Compliance4/FLtest1/
     exit 0
 fi
 

--- a/.github/install_examples.sh
+++ b/.github/install_examples.sh
@@ -2,6 +2,22 @@
 # Script that generates the required target files for each example project
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | sed 's/^1\.//' | cut -d'.' -f1)
 
+# Java version needs to be lower than 11, since support was dropped
+# If the source version is 1.1 OR 1.2, we can only install JUnit3 tests AND we need to use 1.3 as the source version since Java 8 does not support earlier versions
+if [ $JAVA_MAJOR_VERSION -lt "11" ] && ([ "$SRC_VERSION" = "1.1" ] || [ "$SRC_VERSION" = "1.2" ]); then
+    mvn clean test -DskipTests -Dmaven.compiler.source="1.2" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL5JUnit3/FLtest1/
+    mvn clean test -DskipTests -Dmaven.compiler.source="1.2" -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL12Compliance4/FLtest1/
+    exit 0
+fi
+
+# Java version needs to be lower than 11, since support was dropped
+# If the source version is 1.3 OR 1.4, we can only install JUnit3 tests
+if [ $JAVA_MAJOR_VERSION -lt "11" ] && ([ "$SRC_VERSION" = "1.3" ] ||  [ "$SRC_VERSION" = "1.4" ]); then
+    mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL5JUnit3/FLtest1/
+    mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL12Compliance4/FLtest1/
+    exit 0
+fi
+
 # Compile maven projects
 mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL1/FLtest1/
 mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler.target=$SRC_VERSION -B -f examples/exampleFL2/FLtest1/
@@ -15,11 +31,6 @@ mvn clean test -DskipTests -Dmaven.compiler.source=$SRC_VERSION -Dmaven.compiler
 # Compile real projects
 if [ $JAVA_MAJOR_VERSION -eq "8" ]; then
     mvn clean test -DskipTests -Dmaven.compiler.source=1.8 -Dmaven.compiler.target=1.8 -B -f examples/math_70/
-fi
-
-# We only execute this example test if the java version is lower than 11, since the compliance level 1.4 was dropped in 11
-if [ $JAVA_MAJOR_VERSION -lt "11" ]; then
-    mvn clean test -DskipTests -Dmaven.compiler.source=1.4 -Dmaven.compiler.target=1.4 -B -f examples/exampleFL12Compliance4/FLtest1/
 fi
 
 # Copy compiled classes to non-maven mirror projects

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,27 +9,33 @@ jobs:
     strategy:
       matrix:
         java-version: [ 8 , 11 , 14 , 16 ]
-        compiler-version: [ 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 ]
+        compiler-version: [ 1.1 , 1.2 , 1.3 , 1.4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 ]
         os: [ ubuntu-latest , macos-latest , windows-latest ]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
         if: ${{ matrix.compiler-version <= matrix.java-version && (matrix.java-version < 14 || matrix.compiler-version >= 7) && (matrix.java-version < 11 || matrix.compiler-version >= 6) }}
+
       - name: Setup JDK${{ matrix.java-version }}
         uses: actions/setup-java@v2
         if: ${{ matrix.compiler-version <= matrix.java-version && (matrix.java-version < 14 || matrix.compiler-version >= 7) && (matrix.java-version < 11 || matrix.compiler-version >= 6) }}
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'adopt'
+
       - name: Install example projects
         run: ./.github/install_examples.sh
         if: ${{ matrix.compiler-version <= matrix.java-version && (matrix.java-version < 14 || matrix.compiler-version >= 7) && (matrix.java-version < 11 || matrix.compiler-version >= 6) }}
         shell: bash
         env:
           SRC_VERSION: ${{ matrix.compiler-version }}
+
       - name: Build and run tests
         run: mvn --batch-mode clean test
         if: ${{ matrix.compiler-version <= matrix.java-version && (matrix.java-version < 14 || matrix.compiler-version >= 7) && (matrix.java-version < 11 || matrix.compiler-version >= 6) }}
+        env:
+          SRC_VERSION: ${{ matrix.compiler-version }}
+
       - name: Codecov
         uses: codecov/codecov-action@v1.5.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,3 +39,4 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@v1.5.2
+        if: ${{ matrix.compiler-version == 8 && matrix.java-version == 8 && matrix.os == 'ubuntu-latest' }}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 * **Ease of use**: With an intuitive, reliable and stable API, flacoco can be easily used in other projects such as automated program repair tools.
 * **Compatibility**: 
-    * Supports JUnit3, Junit4 and JUni5.
-    * Supports Java 5 to Java 16 bytecode.
+    * Supports JUnit3, Junit4 and JUnit5.
+    * Supports Java 1 to Java 16 bytecode.
     * Runs on Java 8 to Java 16.
     * Runs on Linux, MacOS and Windows.
 * **Stability**: Tests are executed in an isolated JVM.

--- a/src/test/java/fr/spoonlabs/flacoco/TestUtils.java
+++ b/src/test/java/fr/spoonlabs/flacoco/TestUtils.java
@@ -23,7 +23,6 @@ public class TestUtils {
 
     public static int getCompilerVersion() {
         String version = System.getenv("SRC_VERSION");
-        System.out.println(version);
 
         // Java 4 or lower: 1.1, 1.2, 1.3, 1.4
         // Java 9 or higher: 5, 6, 7, 8, 9, ...

--- a/src/test/java/fr/spoonlabs/flacoco/TestUtils.java
+++ b/src/test/java/fr/spoonlabs/flacoco/TestUtils.java
@@ -20,4 +20,18 @@ public class TestUtils {
 
         return Integer.parseInt(version);
     }
+
+    public static int getCompilerVersion() {
+        String version = System.getenv("SRC_VERSION");
+        System.out.println(version);
+
+        // Java 4 or lower: 1.1, 1.2, 1.3, 1.4
+        // Java 9 or higher: 5, 6, 7, 8, 9, ...
+        if(version.startsWith("1.")) {
+            version = version.substring(2, 3);
+        }
+
+        return Integer.parseInt(version);
+    }
+
 }

--- a/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/FlacocoTest.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static fr.spoonlabs.flacoco.TestUtils.isLessThanJava11;
+import static fr.spoonlabs.flacoco.TestUtils.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -38,6 +38,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -73,6 +76,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiDefaultModeThreshold() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -102,6 +108,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiDefaultModeIncludeZero() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -143,6 +152,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiDefaultModeManualTestConfig() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -182,6 +194,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiDefaultModeIgnoreFailingTest() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -214,6 +229,9 @@ public class FlacocoTest {
 	 */
 	@Test
 	public void testExampleFL2SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL2/FLtest1").getAbsolutePath());
@@ -248,6 +266,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL3SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL3/FLtest1").getAbsolutePath());
@@ -281,6 +302,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -321,6 +345,9 @@ public class FlacocoTest {
 	 */
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiNoCoverTestsIncludesDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -354,6 +381,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL1SpectrumBasedOchiaiSpoonMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL1/FLtest1").getAbsolutePath());
@@ -400,6 +430,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL4JUnit5/FLtest1").getAbsolutePath());
@@ -431,6 +464,9 @@ public class FlacocoTest {
 	@Test
 	@Ignore
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiDefaultModeManualTestConfig() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL4JUnit5/FLtest1").getAbsolutePath());
@@ -469,6 +505,9 @@ public class FlacocoTest {
 	@Test
 	@Ignore
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL4JUnit5/FLtest1").getAbsolutePath());
@@ -503,6 +542,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL4JUnit5SpectrumBasedOchiaiSpoonMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL4JUnit5/FLtest1").getAbsolutePath());
@@ -547,6 +589,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL5JUnit3SpectrumBasedOchiaiDefaultMode() {
+		// Run only on all compiler versions
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL5JUnit3/FLtest1").getAbsolutePath());
@@ -578,6 +623,9 @@ public class FlacocoTest {
 	@Test
 	@Ignore
 	public void testExampleFL5JUnit3SpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Run only on all compiler versions
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL5JUnit3/FLtest1").getAbsolutePath());
@@ -612,6 +660,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL5JUnit3SpectrumBasedOchiaiSpoonMode() {
+		// Run only on all compiler versions
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL5JUnit3/FLtest1").getAbsolutePath());
@@ -656,6 +707,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL6MixedSpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL6Mixed/FLtest1").getAbsolutePath());
@@ -686,6 +740,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL6MixedSpectrumBasedOchiaiDefaultModeManualTestConfig() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL6Mixed/FLtest1").getAbsolutePath());
@@ -727,6 +784,9 @@ public class FlacocoTest {
 	@Test
 	@Ignore
 	public void testExampleFL6MixedSpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL6Mixed/FLtest1").getAbsolutePath());
@@ -761,6 +821,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL6MixedSpectrumBasedOchiaiSpoonMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL6Mixed/FLtest1").getAbsolutePath());
@@ -805,6 +868,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL7SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL7SameNamedMethods/FLtest1").getAbsolutePath());
@@ -837,6 +903,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL8SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		// we don't set --projectpath because it is not needed when we explicit the other 4 dirs
@@ -874,6 +943,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL8SpectrumBasedOchiaiCoverTestsDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath("./examples/exampleFL8NotMaven/");
@@ -914,6 +986,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL8SpectrumBasedOchiaiSpoonMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath("./examples/exampleFL8NotMaven/");
@@ -964,6 +1039,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL9SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath("./examples/exampleFL9NotMavenMultiple/");
@@ -1000,6 +1078,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL9SpectrumBasedOchiaiSpoonMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath("./examples/exampleFL9NotMavenMultiple/");
@@ -1050,6 +1131,9 @@ public class FlacocoTest {
 
 	@Test
 	public void testExampleFL11SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = getDefaultFlacocoConfig();
 		config.setProjectPath(new File("./examples/exampleFL11/FLtest1").getAbsolutePath());
@@ -1089,6 +1173,9 @@ public class FlacocoTest {
 	 */
 	@Test
 	public void testExampleFL12SpectrumBasedOchiaiDefaultMode() {
+		// Run only on target release < 5
+		Assume.assumeTrue(getCompilerVersion() < 5);
+
 		// We can only run this test on java version less than 11
 		// since java 11 dropped support for compliance level 1.4
 		Assume.assumeTrue(isLessThanJava11());

--- a/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
+++ b/src/test/java/fr/spoonlabs/flacoco/api/Math70Test.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static fr.spoonlabs.flacoco.TestUtils.getJavaVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,6 +32,9 @@ public class Math70Test {
 
     @Before
     public void setUp() {
+        // Run only on target release >= 5
+        Assume.assumeTrue(getCompilerVersion() >= 5);
+
         // Run only on Java8
         Assume.assumeTrue(getJavaVersion() == 8);
         // FIXME: In CI, `testMath70` fails due to the test-runner args being too big (#57)

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -7,10 +7,7 @@ import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -21,6 +18,7 @@ import picocli.CommandLine;
 import java.io.File;
 import java.io.IOException;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static org.junit.Assert.assertTrue;
 
 public class FlacocoMainTest {
@@ -38,6 +36,8 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainExplicitArguments() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// It's a smoke test
 		String mavenHome = System.getProperty("user.home") + "/.m2/repository/";
@@ -78,6 +78,8 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainExplicitArgumentsNotMaven() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// It's a smoke test
 		String mavenHome = System.getProperty("user.home") + "/.m2/repository/";
@@ -127,6 +129,8 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainDefaultValues() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// It's a smoke test
 
@@ -138,6 +142,9 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainCSVExport() throws IOException {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// setup check output rule
 		output.extension = new CSVExporter().extension();
 
@@ -151,6 +158,9 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainJSONExport() throws IOException {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// setup check output rule
 		output.extension = new JSONExporter().extension();
 
@@ -164,6 +174,9 @@ public class FlacocoMainTest {
 
 	@Test
 	public void testMainCustomExport() throws IOException {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// setup check output rule
 		output.extension = "custom";
 

--- a/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunnerTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static fr.spoonlabs.flacoco.TestUtils.isLessThanJava11;
 import static org.junit.Assert.*;
 
@@ -33,6 +34,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL1() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -136,6 +140,9 @@ public class CoverageRunnerTest {
 	 */
 	@Test
 	public void testExampleFL2() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -175,6 +182,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL3() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -213,6 +223,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL1CoverTests() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -254,6 +267,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL4JUnit5() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -353,6 +369,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL5JUnit3() {
+		// Run on all target releases
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -452,6 +471,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL6Mixed() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -551,6 +573,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testTimeout() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -571,6 +596,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testJVMArgs() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -672,6 +700,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL7() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -771,6 +802,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL8() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -875,6 +909,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL9() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -978,6 +1015,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL11() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -1077,6 +1117,9 @@ public class CoverageRunnerTest {
 
 	@Test
 	public void testExampleFL12() {
+		// Run only on target release < 5
+		Assume.assumeTrue(getCompilerVersion() < 5);
+
 		// We can only run this test on java version less than 11
 		// since java 11 dropped support for compliance level 1.4
 		Assume.assumeTrue(isLessThanJava11());

--- a/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/core/test/TestDetectorTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static fr.spoonlabs.flacoco.TestUtils.isLessThanJava11;
 import static org.junit.Assert.*;
 
@@ -35,6 +36,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -86,6 +90,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1TestRunnerDetector() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -108,6 +115,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1IgnoreTestClass() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -125,6 +135,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1IgnoreTestMethod() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -147,6 +160,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1TestRunnerDetectorIgnoreTestClass() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -165,6 +181,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL1TestRunnerDetectorIgnoreTestMethod() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -188,6 +207,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL2() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -209,6 +231,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL3() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -230,6 +255,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL4JUnit5() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -251,6 +279,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL4JUnit5ManualConfig() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -281,6 +312,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL5JUnit3() {
+		// Run on all target releases
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -302,6 +336,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL6Mixed() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -343,6 +380,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL6MixedManualConfig() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -396,6 +436,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL7() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -417,6 +460,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL8() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -442,6 +488,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL9() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -467,6 +516,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL11() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -488,6 +540,9 @@ public class TestDetectorTest {
 
 	@Test
 	public void testExampleFL12() {
+		// Run only on target release < 5
+		Assume.assumeTrue(getCompilerVersion() < 5);
+
 		// We can only run this test on java version less than 11
 		// since java 11 dropped support for compliance level 1.4
 		Assume.assumeTrue(isLessThanJava11());

--- a/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/localization/spectrum/SpectrumRunnerTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static fr.spoonlabs.flacoco.TestUtils.isLessThanJava11;
 import static org.junit.Assert.assertEquals;
 
@@ -34,6 +35,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL1Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -67,6 +71,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL2Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -102,6 +109,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL3Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -136,6 +146,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL1OchiaiCoverTests() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -173,6 +186,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL4JUnit5Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -205,6 +221,9 @@ public class SpectrumRunnerTest {
 	@Test
 	@Ignore
 	public void testExampleFL4JUnit5OchiaiCoverTests() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -240,6 +259,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL5JUnit3Ochiai() {
+		// Run only on all target releases
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -272,6 +294,9 @@ public class SpectrumRunnerTest {
 	@Test
 	@Ignore
 	public void testExampleFL5JUnit3OchiaiCoverTests() {
+		// Run only on all target releases
+		Assume.assumeTrue(getCompilerVersion() >= 1);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -307,6 +332,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL6MixedOchiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -339,6 +367,9 @@ public class SpectrumRunnerTest {
 	@Test
 	@Ignore
 	public void testExampleFL6MixedOchiaiCoverTests() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -374,6 +405,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL7Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -407,6 +441,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL8Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -444,6 +481,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL9Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -481,6 +521,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL11Ochiai() {
+		// Run only on target release >= 5
+		Assume.assumeTrue(getCompilerVersion() >= 5);
+
 		// Setup config
 		FlacocoConfig config = new FlacocoConfig();
 		config.setWorkspace(workspaceDir.getRoot().getAbsolutePath());
@@ -518,6 +561,9 @@ public class SpectrumRunnerTest {
 
 	@Test
 	public void testExampleFL12Ochiai() {
+		// Run only on target release < 5
+		Assume.assumeTrue(getCompilerVersion() < 5);
+
 		// We can only run this test on java version less than 11
 		// since java 11 dropped support for compliance level 1.4
 		Assume.assumeTrue(isLessThanJava11());

--- a/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/utils/spoon/SpoonConverterTest.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
This PR fixes the gap in CI, where the 4 first major versions of the Java instruction set weren't covered.

Jacoco supports 1 to 16 right now, so we can also claim that we do so.