### PR TITLE
removing log line debug mode

### DIFF
--- a/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
+++ b/src/main/java/fr/spoonlabs/flacoco/core/coverage/CoverageRunner.java
@@ -1,19 +1,20 @@
 package fr.spoonlabs.flacoco.core.coverage;
 
-import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
-import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
-import fr.spoonlabs.flacoco.core.test.TestContext;
-import fr.spoonlabs.flacoco.core.test.method.TestMethod;
-import org.apache.log4j.Logger;
-
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import org.apache.log4j.Logger;
+
+import eu.stamp_project.testrunner.listener.CoveredTestResultPerTestMethod;
+import fr.spoonlabs.flacoco.core.config.FlacocoConfig;
+import fr.spoonlabs.flacoco.core.test.TestContext;
+import fr.spoonlabs.flacoco.core.test.method.TestMethod;
+
 /**
- * Class for running the coverage runner from test-runner and computing
- * the coverage matrix.
+ * Class for running the coverage runner from test-runner and computing the
+ * coverage matrix.
  *
  * @author Matias Martinez
  */
@@ -32,11 +33,8 @@ public class CoverageRunner {
 		// that execution on each line
 		CoverageMatrix matrixExecutionResult = new CoverageMatrix(config);
 
-		Set<String> testClasses = testContexts.stream()
-				.map(TestContext::getTestMethods)
-				.flatMap(List::stream)
-				.map(TestMethod::getFullyQualifiedClassName)
-				.collect(Collectors.toSet());
+		Set<String> testClasses = testContexts.stream().map(TestContext::getTestMethods).flatMap(List::stream)
+				.map(TestMethod::getFullyQualifiedClassName).collect(Collectors.toSet());
 
 		// For each test context
 		int executedTests = 0;
@@ -48,14 +46,13 @@ public class CoverageRunner {
 				// We run the test cases according to the specific test framework strategy
 				CoveredTestResultPerTestMethod result = testContext.getTestFrameworkStrategy().execute(testContext);
 
-				this.logger.debug(result);
-
 				// Process each method individually
 				for (TestMethod testMethod : testContext.getTestMethods()) {
 					testsFound++;
 
 					if (result.getCoverageResultsMap().containsKey(testMethod.getFullyQualifiedMethodName())) {
-						matrixExecutionResult.processSingleTest(new CoverageFromSingleTestUnit(testMethod, result), testClasses);
+						matrixExecutionResult.processSingleTest(new CoverageFromSingleTestUnit(testMethod, result),
+								testClasses);
 						executedTests++;
 					} else {
 						this.logger.warn("Test " + testMethod + " result was not reported by test-runner.");


### PR DESCRIPTION
Removing logging line at debug which prints all coverage information and crashes when analyzing large projects.
Without this change, we cannot use clients such as Astor in debug mode.

I will release new version 1.0.1