### PR TITLE
Bump `test-runner` to `3.1.0-SNAPSHOT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
`test-runner` now supports compressed coverage matrixes