### PR TITLE
Bump `test-runner` to `3.1.3`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes issue with too high log level disturbing flacoco's output