### PR TITLE
Java 17 and 18 support

### DIFF
--- a/.github/workflows/deploy-snapshot.yml
+++ b/.github/workflows/deploy-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: ossrh-flacoco-snapshots
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         if: ${{ matrix.compiler-version <= matrix.java-version && (matrix.java-version < 14 || matrix.compiler-version >= 7) && (matrix.java-version < 11 || matrix.compiler-version >= 6) }}
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - name: Install example projects
         run: ./.github/install_examples.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8 , 11 , 14 , 16 , 18 ]
+        java-version: [ 8 , 11 , 16 , 18 ]
         compiler-version: [ 1.1 , 1.2 , 1.3 , 1.4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 , 17 , 18 ]
         os: [ ubuntu-latest , macos-latest , windows-latest ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ 8 , 11 , 14 , 16 ]
-        compiler-version: [ 1.1 , 1.2 , 1.3 , 1.4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 ]
+        java-version: [ 8 , 11 , 14 , 16 , 18 ]
+        compiler-version: [ 1.1 , 1.2 , 1.3 , 1.4 , 5 , 6 , 7 , 8 , 9 , 10 , 11 , 12 , 13 , 14 , 15 , 16 , 17 , 18 ]
         os: [ ubuntu-latest , macos-latest , windows-latest ]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 * **Ease of use**: With an intuitive, reliable and stable API, flacoco can be easily used in other projects such as automated program repair tools.
 * **Compatibility**: 
     * Supports JUnit3, Junit4 and JUnit5.
-    * Supports Java 1 to Java 16 bytecode.
-    * Runs on Java 8 to Java 16.
+    * Supports Java 1 to Java 18 bytecode.
+    * Runs on Java 8 to Java 18.
     * Runs on Linux, MacOS and Windows.
 * **Stability**: Tests are executed in an isolated JVM.
 

--- a/pom.xml
+++ b/pom.xml
@@ -136,9 +136,8 @@
         <!-- for testing System.exit -->
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <version>1.19.0</version>
-            <scope>test</scope>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
         </dependency>
 
         <!-- for mocks -->

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,39 @@
 
     <profiles>
         <profile>
+            <id>surefire-java16-and-below</id>
+            <activation>
+                <jdk>(,17)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.1</version>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>surefire-java17-and-above</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.1</version>
+                        <configuration>
+                            <argLine>-Djava.security.manager=allow</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>eu.stamp-project</groupId>
             <artifactId>test-runner</artifactId>
-            <version>3.1.4-SNAPSHOT</version>
+            <version>4.7</version>
         </dependency>
 
         <dependency>
@@ -184,7 +184,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.8</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -7,10 +7,10 @@ import fr.spoonlabs.flacoco.localization.spectrum.SpectrumFormula;
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
-import org.junit.*;
-import org.junit.contrib.java.lang.system.ExpectedSystemExit;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TestRule;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 import picocli.CommandLine;
@@ -18,16 +18,15 @@ import picocli.CommandLine;
 import java.io.File;
 import java.io.IOException;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.catchSystemExit;
 import static fr.spoonlabs.flacoco.TestUtils.getCompilerVersion;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class FlacocoMainTest {
 
-	public final ExpectedSystemExit exit = ExpectedSystemExit.none();
-	public final CheckOutput output = new CheckOutput();
-
 	@Rule
-	public TestRule allRules = RuleChain.outerRule(output).around(exit);
+	public final CheckOutput output = new CheckOutput();
 
 	@Before
 	public void setUp() {
@@ -35,7 +34,7 @@ public class FlacocoMainTest {
 	}
 
 	@Test
-	public void testMainExplicitArguments() {
+	public void testMainExplicitArguments() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
@@ -53,8 +52,7 @@ public class FlacocoMainTest {
 				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
 		String jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.3/org.jacoco.core-0.8.3.jar";
 
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projectpath", "examples/exampleFL1/FLtest1",
 				"--formula", SpectrumFormula.OCHIAI.name(),
 				"--mavenHome", mavenHome,
@@ -73,11 +71,12 @@ public class FlacocoMainTest {
 				"--jacocoIncludes", "fr.spoonlabs.FLtest1.*",
 				"--jacocoExcludes", "org.junit.*",
 				"--complianceLevel", "8"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	@Test
-	public void testMainExplicitArgumentsNotMaven() {
+	public void testMainExplicitArgumentsNotMaven() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
@@ -95,8 +94,7 @@ public class FlacocoMainTest {
 				+ mavenHome + "org/junit/platform/junit-platform-launcher/1.3.2/junit-platform-launcher-1.3.2.jar";
 		String jacocoClassPath = mavenHome + "org/jacoco/org.jacoco.core/0.8.3/org.jacoco.core-0.8.3.jar";
 
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				// we don't set --projectpath because it is not needed when we explicit the other 4 dirs
 				"--srcJavaDir", "examples/exampleFL8NotMaven/java",
 				"--srcTestDir", "examples/exampleFL8NotMaven/test",
@@ -112,80 +110,80 @@ public class FlacocoMainTest {
 				"--testRunnerJVMArgs", "-Xms16M",
 				"-v",
 				"--includeZeros"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	@Test
-	public void testMainIncorrectInputs() {
+	public void testMainIncorrectInputs() throws Exception {
 
-		exit.expectSystemExitWithStatus(CommandLine.ExitCode.USAGE);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projhjhjhectpathddd", // Incorrect argument
 				"examples/exampleFL1/FLtest1",
 				"--formula", SpectrumFormula.OCHIAI.name(),
 				"--coverTest"
-		});
+		}));
+		assertEquals(CommandLine.ExitCode.USAGE, statusCode);
 	}
 
 	@Test
-	public void testMainDefaultValues() {
+	public void testMainDefaultValues() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// It's a smoke test
-
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projectpath", "examples/exampleFL1/FLtest1"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	@Test
-	public void testMainCSVExport() throws IOException {
+	public void testMainCSVExport() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// setup check output rule
 		output.extension = new CSVExporter().extension();
 
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projectpath", "examples/exampleFL1/FLtest1",
 				"--format", "CSV",
 				"-o", "results.csv"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	@Test
-	public void testMainJSONExport() throws IOException {
+	public void testMainJSONExport() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// setup check output rule
 		output.extension = new JSONExporter().extension();
 
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projectpath", "examples/exampleFL1/FLtest1",
 				"--format", "JSON",
 				"-o", "results.json"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	@Test
-	public void testMainCustomExport() throws IOException {
+	public void testMainCustomExport() throws Exception {
 		// Run only on target release >= 5
 		Assume.assumeTrue(getCompilerVersion() >= 5);
 
 		// setup check output rule
 		output.extension = "custom";
 
-		exit.expectSystemExitWithStatus(0);
-		FlacocoMain.main(new String[]{
+		int statusCode = catchSystemExit(() -> FlacocoMain.main(new String[]{
 				"--projectpath", "examples/exampleFL1/FLtest1",
 				"--formatter", "src/test/resources/OneLineExporter.java",
 				"-o", "results.custom"
-		});
+		}));
+		assertEquals(0, statusCode);
 	}
 
 	private static final class CheckOutput extends TestWatcher {


### PR DESCRIPTION
- Bumps test-runner to 4.7
- Bumps jacoco to 0.8.8
- Adds Java 17 and 18 to CI setup, as jacoco now officially supports those versions