### PR TITLE
fix JUnit dependencies in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>5.3.2</version>

--- a/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
+++ b/src/test/java/fr/spoonlabs/flacoco/cli/FlacocoMainTest.java
@@ -40,7 +40,7 @@ public class FlacocoMainTest {
 
 		// It's a smoke test
 		String mavenHome = System.getProperty("user.home") + "/.m2/repository/";
-		String junitClasspath = mavenHome + "junit/junit/4.12/junit-4.12.jar" + File.pathSeparatorChar
+		String junitClasspath = mavenHome + "junit/junit/4.13.2/junit-4.13.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar
@@ -82,7 +82,7 @@ public class FlacocoMainTest {
 
 		// It's a smoke test
 		String mavenHome = System.getProperty("user.home") + "/.m2/repository/";
-		String junitClasspath = mavenHome + "junit/junit/4.12/junit-4.12.jar" + File.pathSeparatorChar
+		String junitClasspath = mavenHome + "junit/junit/4.13.2/junit-4.13.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/junit/jupiter/junit-jupiter-api/5.3.2/junit-jupiter-api-5.3.2.jar" + File.pathSeparatorChar
 				+ mavenHome + "org/apiguardian/apiguardian-api/1.0.0/apiguardian-api-1.0.0.jar" + File.pathSeparatorChar


### PR DESCRIPTION
#205 introduced a regression in tests, since our hardcoded dependency paths to JUnit 4.12 stopped existing with it in some of the CI cases.

This PR fixes this issue by updating the dependency paths in the tests with the versions declared in flacoco's `pom.xml`.